### PR TITLE
Fix HTTP 400 on books with non-ASCII text (Cyrillic/CJK/curly quotes)

### DIFF
--- a/xray.koplugin/xray_aihelper.lua
+++ b/xray.koplugin/xray_aihelper.lua
@@ -38,6 +38,64 @@ function AIHelper:log(message)
     XRayLogger:log(message)
 end
 
+-- Strip invalid UTF-8 sequences and disallowed control bytes from a string.
+-- Byte-based string.sub() throughout the plugin can slice multi-byte UTF-8
+-- characters mid-sequence, leaving an invalid prefix/suffix that makes the
+-- JSON request body non-parseable to strict APIs like OpenAI's.
+local function sanitize_utf8(s)
+    if not s or s == "" then return s or "" end
+    local out, i, len = {}, 1, #s
+    while i <= len do
+        local b = s:byte(i)
+        if b < 0x80 then
+            -- ASCII: keep printable + tab/LF/CR, replace other C0 controls with space
+            if b >= 0x20 or b == 0x09 or b == 0x0A or b == 0x0D then
+                out[#out+1] = string.char(b)
+            else
+                out[#out+1] = " "
+            end
+            i = i + 1
+        elseif b < 0xC2 then
+            -- Stray continuation byte (0x80-0xBF) or overlong start (0xC0-0xC1): drop
+            i = i + 1
+        elseif b < 0xE0 then
+            -- 2-byte sequence
+            local b2 = s:byte(i + 1)
+            if b2 and b2 >= 0x80 and b2 < 0xC0 then
+                out[#out+1] = s:sub(i, i + 1)
+                i = i + 2
+            else
+                i = i + 1
+            end
+        elseif b < 0xF0 then
+            -- 3-byte sequence
+            local b2, b3 = s:byte(i + 1), s:byte(i + 2)
+            if b2 and b3 and b2 >= 0x80 and b2 < 0xC0 and b3 >= 0x80 and b3 < 0xC0 then
+                out[#out+1] = s:sub(i, i + 2)
+                i = i + 3
+            else
+                i = i + 1
+            end
+        elseif b < 0xF5 then
+            -- 4-byte sequence
+            local b2, b3, b4 = s:byte(i + 1), s:byte(i + 2), s:byte(i + 3)
+            if b2 and b3 and b4
+                and b2 >= 0x80 and b2 < 0xC0
+                and b3 >= 0x80 and b3 < 0xC0
+                and b4 >= 0x80 and b4 < 0xC0 then
+                out[#out+1] = s:sub(i, i + 3)
+                i = i + 4
+            else
+                i = i + 1
+            end
+        else
+            -- Invalid leading byte (0xF5-0xFF)
+            i = i + 1
+        end
+    end
+    return table.concat(out)
+end
+
 function AIHelper:setTrapWidget(trap_widget) self.trap_widget = trap_widget end
 function AIHelper:resetTrapWidget() self.trap_widget = nil end
 
@@ -719,6 +777,14 @@ function AIHelper:createPrompt(title, author, context, section_name)
     end
     if not success then final_prompt = string.format("Book: %s - Author: %s. Extract %s data.", enhanced_title, enhanced_author, section_name) end
     if #extra_context > 0 then final_prompt = final_prompt .. extra_context end
+
+    -- Strip invalid UTF-8 introduced by byte-based truncation of multi-byte
+    -- text (Cyrillic, CJK, curly quotes, etc.) before the prompt is JSON-encoded.
+    local before_len = #final_prompt
+    final_prompt = sanitize_utf8(final_prompt)
+    if #final_prompt ~= before_len then
+        self:log(string.format("AIHelper: sanitize_utf8 stripped %d invalid byte(s) from prompt", before_len - #final_prompt))
+    end
     return final_prompt
 end
 


### PR DESCRIPTION
## Problem
Fetches fail with `HTTP 400: There was an error parsing the body` for any book whose text contains multi-byte UTF-8 (Cyrillic, CJK, em dashes, curly quotes, emoji…). Pure-ASCII English books work fine.

Same code path, only the body bytes differ — so the API is rejecting the request body itself before reaching the prompt.

## Root cause
The chapter analyzer truncates and samples extracted text using `string.sub`, which is **byte-based** in Lua. For ASCII (1 byte/char) that is harmless, but for multi-byte UTF-8 it slices mid-codepoint at every boundary:

- `xray_chapteranalyzer.lua:528` — `book_text:sub(-max_len)`
- `xray_chapteranalyzer.lua:692` — `chapter_text:sub(1, sample_len)`
- `xray_chapteranalyzer.lua:694` — `chapter_text:sub(mid_start, mid_start + sample_len)`
- `xray_chapteranalyzer.lua:695` — `chapter_text:sub(-sample_len)`
- plus several others

Each cut leaves either a stray UTF-8 continuation byte at the start or an incomplete leading byte at the end. Once those bytes are inlined into the prompt and passed through `json.encode`, the resulting body is no longer valid UTF-8, and OpenAI's strict parser rejects it.

Verified against a real corruption case — `"Атлант розправив плечі"` byte-truncated to 11 bytes is undecodable; after sanitization it is `"Атлан"`, valid UTF-8.

## Fix
Add a `sanitize_utf8` helper to `xray_aihelper.lua` and call it once in `createPrompt`, the single chokepoint every Gemini and ChatGPT request flows through. The sanitizer:

- Validates each UTF-8 sequence (1/2/3/4 byte) and drops any incomplete or stray bytes.
- Drops stray continuation bytes (0x80–0xBF) and overlong/invalid leading bytes (0xC0–0xC1, 0xF5–0xFF).
- Replaces C0 control bytes with a space, except `\t`, `\n`, `\r`.

When anything is stripped, a single log line records the byte count so the fix is observable in the X-Ray log.

## Why fix at the prompt, not the analyzer
The analyzer has many `:sub` call sites; per-site fixes are invasive and easy to regress. A single sanitize at the JSON-encode boundary is a thin, defensive layer that protects every current and future call path with a small constant overhead per fetch.

## Test plan
- [x] Open a Cyrillic-language book that previously failed (e.g. an Ukrainian EPUB) and trigger an X-Ray fetch.
- [x] Confirm the request now returns `200` instead of `400: There was an error parsing the body`.
- [x] Confirm an English book still fetches successfully (no regression).
- [x] Optionally check the X-Ray log for `AIHelper: sanitize_utf8 stripped N invalid byte(s) from prompt` lines, which confirm the truncation issue was real.