### PR TITLE
﻿Fix CJK search lookup normalization, UI truncation errors, and alias…

### DIFF
--- a/spec/spec_helper.lua
+++ b/spec/spec_helper.lua
@@ -275,6 +275,15 @@ package.loaded["ssl.https"] = {}
 package.loaded["ltn12"] = {}
 package.loaded["socket"] = {}
 package.loaded["socketutil"] = {}
+package.loaded["util"] = {
+    splitToChars = function(text)
+        local chars = {}
+        for c in text:gmatch("[%z\1-\127\194-\244][\128-\191]*") do
+            table.insert(chars, c)
+        end
+        return chars
+    end
+}
 local json_lib = nil
 pcall(function() json_lib = require("dkjson") end)
 if not json_lib then

--- a/xray.koplugin/languages/zh_CN.po
+++ b/xray.koplugin/languages/zh_CN.po
@@ -439,7 +439,7 @@ msgstr "整本书模式"
 
 # en-hash: 9ab81f57823f6aeb02362291f23883e6
 msgid "label_aliases"
-msgstr "??"
+msgstr "别名"
 
 # en-hash: e38583f3a073fa2a86a841b672aba548
 msgid "label_category"

--- a/xray.koplugin/xray_aihelper.lua
+++ b/xray.koplugin/xray_aihelper.lua
@@ -9,6 +9,7 @@ local logger = require("logger")
 local plugin_path = ((...) or ""):match("(.-)[^%.]+$") or ""
 local XRayLogger = require(plugin_path .. "xray_logger")
 local Trapper = require("ui/trapper")
+local utils = require(plugin_path .. "xray_utils")
 
 -- Optimization: Use rapidjson if available
 local json_ok, json = pcall(require, "json")
@@ -1902,6 +1903,9 @@ function AIHelper:validateAndCleanData(data)
     if data.is_valid ~= nil or data.duplicate_pairs ~= nil or data.DuplicatePairs ~= nil then return data end
     
     local strings = self:getFallbackStrings()
+    local function _truncateSafe(text, limit)
+        return (utils:getTruncatedText(text, limit))
+    end
     local function ensureString(v, d) return (type(v) == "string" and #v > 0) and v or d or "" end
     
     local chars = data.characters or data.Characters or {}
@@ -1910,7 +1914,7 @@ function AIHelper:validateAndCleanData(data)
         if type(c) == "table" then
             table.insert(valid_chars, {
                 name = ensureString(c.name or c.full_formal_name or c.full_name or c.formal_name or c.Name, strings.unnamed_character),
-                role = ensureString(c.role or c.Role, strings.not_specified):sub(1, 40),
+                role = _truncateSafe(ensureString(c.role or c.Role, strings.not_specified), 40),
                 description = ensureString(c.description or c.bio or c.history or c.desc, strings.no_description),
                 gender = ensureString(c.gender or c.Gender, ""),
                 occupation = ensureString(c.occupation or c.job or c.Occupation, ""),
@@ -1927,7 +1931,7 @@ function AIHelper:validateAndCleanData(data)
             table.insert(valid_hists, {
                 name = ensureString(h.name or h.Name, strings.unnamed_person),
                 biography = ensureString(h.biography or h.bio or h.description, strings.no_biography),
-                role = ensureString(h.role or h.historical_role, ""):sub(1, 40),
+                role = _truncateSafe(ensureString(h.role or h.historical_role, ""), 40),
                 importance_in_book = ensureString(h.importance_in_book or h.significance, "Mentioned"),
                 context_in_book = ensureString(h.context_in_book or h.context, "Historical")
             })

--- a/xray.koplugin/xray_fetch.lua
+++ b/xray.koplugin/xray_fetch.lua
@@ -8,6 +8,11 @@ local logger = require("logger")
 local plugin_path = ((...) or ""):match("(.-)[^%.]+$") or ""
 local utils = require(plugin_path .. "xray_utils")
 
+local function _truncateSafe(text, limit)
+    return (utils:getTruncatedText(text, limit))
+end
+
+
 local M = {}
 
 local function sanitizeMetadata(val)
@@ -62,7 +67,7 @@ function M:fetchSingleWord(text, pos0, pos1)
         local ButtonDialog = require("ui/widget/buttondialog")
         local is_cancelled = false
         local wait_msg = ButtonDialog:new{
-            title = self.loc:t("looking_up_msg", text:sub(1, 30)),
+            title = self.loc:t("looking_up_msg", _truncateSafe(text, 30)),
             text = text,
             buttons = {{{
                 text = self.loc:t("cancel") or "Cancel",
@@ -219,7 +224,7 @@ function M:fetchSingleWord(text, pos0, pos1)
                 -- Always show result if it's valid, even if it didn't merge into a target_list
                 self.lookup_manager:showResult(item, item_type)
             else
-                local err = result.error_message or self.loc:t("entity_not_found", text:sub(1, 20))
+                local err = result.error_message or self.loc:t("entity_not_found", _truncateSafe(text, 20))
                 UIManager:show(InfoMessage:new{ text = err, timeout = 5 })
             end
         end)

--- a/xray.koplugin/xray_lookupmanager.lua
+++ b/xray.koplugin/xray_lookupmanager.lua
@@ -19,12 +19,31 @@ function LookupManager:new(plugin)
     return o
 end
 
--- Clean and normalize text for comparison
+-- Clean and normalize text for comparison (Chinese & Multilingual Fixed)
 function LookupManager:normalize(text)
     if type(text) ~= "string" or text == "" then return "" end
-    -- Remove non-alphanumeric characters from start/end and lowercase
-    local clean = text:gsub("^[^%w]+", ""):gsub("[^%w]+$", ""):lower()
-    return clean
+    
+    local is_english = true
+    if self.plugin and self.plugin.ai_helper then
+        local lang = self.plugin.ai_helper.current_language
+        if lang and lang ~= "en" then
+            is_english = false
+        end
+    end
+    
+    if is_english and text:find("[^\1-\127]") then
+        is_english = false
+    end
+    
+    if is_english then
+        local clean = text:gsub("^[^%w]+", ""):gsub("[^%w]+$", ""):lower()
+        return clean
+    else
+        local clean = text:match("^%s*(.-)%s*$") or text
+        clean = clean:gsub("[%.,%?%!%:%\"%\'“»«”‘，。！？：、•○●□]+$", "")
+        clean = clean:gsub("^[%\"%\'“»«”‘，。！？：、•○●□]+", "")
+        return clean:lower()
+    end
 end
 
 -- Collect all matches from a category list using a test function.

--- a/xray.koplugin/xray_lookupmanager.lua
+++ b/xray.koplugin/xray_lookupmanager.lua
@@ -2,6 +2,8 @@
 local logger = require("logger")
 local UIManager = require("ui/uimanager")
 local InfoMessage = require("ui/widget/infomessage")
+local plugin_path = ((...) or ""):match("(.-)[^%.]+$") or ""
+local utils = require(plugin_path .. "xray_utils")
 
 -- Minimum score to consider a match "high confidence" and skip the re-lookup prompt.
 -- Scores 100 (exact) and 95 (alias exact) are above this; 50/40/30 are below.
@@ -9,6 +11,10 @@ local LOW_CONFIDENCE_THRESHOLD = 70
 
 local LookupManager = {}
 
+
+local function _truncateSafe(text, limit)
+    return (utils:getTruncatedText(text, limit))
+end
 
 function LookupManager:new(plugin)
     local o = {
@@ -242,7 +248,7 @@ function LookupManager:handleLookup(text, pos0, pos1)
     elseif #all > 1 then
         -- Multiple candidates — let the user pick
         local ButtonDialog = require("ui/widget/buttondialog")
-        local prompt = self.plugin.loc:t("multiple_matches", text:sub(1, 30))
+        local prompt = self.plugin.loc:t("multiple_matches", _truncateSafe(text, 30))
         local buttons = {}
         local dialog
 
@@ -283,7 +289,7 @@ function LookupManager:handleLookup(text, pos0, pos1)
         local ConfirmBox = require("ui/widget/confirmbox")
         local no_data_dialog
         
-        local text_to_show = text:sub(1, 30)
+        local text_to_show = _truncateSafe(text, 30)
         local prompt_text = self.plugin.loc:t("fetch_single_word_prompt", text_to_show)
         if not prompt_text or prompt_text == "fetch_single_word_prompt" then
             prompt_text = string.format("No X-Ray data found for '%s'. Would you like to look it up?", text_to_show)

--- a/xray.koplugin/xray_lookupmanager.lua
+++ b/xray.koplugin/xray_lookupmanager.lua
@@ -29,25 +29,15 @@ end
 function LookupManager:normalize(text)
     if type(text) ~= "string" or text == "" then return "" end
     
-    local is_english = true
-    if self.plugin and self.plugin.ai_helper then
-        local lang = self.plugin.ai_helper.current_language
-        if lang and lang ~= "en" then
-            is_english = false
-        end
-    end
-    
-    if is_english and text:find("[^\1-\127]") then
-        is_english = false
-    end
+    local is_english = not utils:textHasCJK(text)
     
     if is_english then
         local clean = text:gsub("^[^%w]+", ""):gsub("[^%w]+$", ""):lower()
         return clean
     else
-        local clean = text:match("^%s*(.-)%s*$") or text
-        clean = clean:gsub("[%.,%?%!%:%\"%\'“»«”‘，。！？：、•○●□]+$", "")
-        clean = clean:gsub("^[%\"%\'“»«”‘，。！？：、•○●□]+", "")
+        -- Use safe ASCII punctuation classes to avoid UTF-8 byte stripping
+        local clean = text:gsub("[%s%p]+$", "")
+        clean = clean:gsub("^[%s%p]+", "")
         return clean:lower()
     end
 end

--- a/xray.koplugin/xray_ui.lua
+++ b/xray.koplugin/xray_ui.lua
@@ -1,4 +1,5 @@
 -- X-Ray UI and Menu Functions
+local util = require("util")
 
 local UIManager = require("ui/uimanager")
 local InfoMessage = require("ui/widget/infomessage")
@@ -54,6 +55,27 @@ local function _textHasCJK(text)
     if type(text) ~= "string" then return false end
     return text:find("[\227-\234][\128-\191][\128-\191]") ~= nil
 end
+
+-- Truncates a string to limit_en characters (scaled down to limit_en/3 if CJK)
+-- only if the total length exceeds threshold_en (scaled down to threshold_en/3 if CJK).
+-- Returns: truncated_text, is_truncated
+local function _getTruncatedText(text, limit_en, threshold_en)
+    if type(text) ~= "string" or text == "" then
+        return "", false
+    end
+    local is_cjk = _textHasCJK(text)
+    
+    local limit = is_cjk and math.floor(limit_en / 3) or limit_en
+    local threshold = is_cjk and math.floor((threshold_en or limit_en) / 3) or (threshold_en or limit_en)
+    
+    local chars = util.splitToChars(text)
+    if #chars > threshold then
+        return table.concat(chars, "", 1, limit), true
+    else
+        return text, false
+    end
+end
+
 
 -- Returns true if the font family name looks like a CJK font
 local function _isCJKFontFamily(family)
@@ -263,9 +285,8 @@ function XRayBottomPopup:init()
     local display_desc = desc_str
     local is_truncated = false
     if desc_str ~= "" then
-        if #desc_str > 400 then
-            is_truncated = true
-            display_desc = desc_str:sub(1, 350)
+        display_desc, is_truncated = _getTruncatedText(desc_str, 350, 400)
+        if is_truncated then
             local last_space = display_desc:match("^.*()%s")
             if last_space then
                 display_desc = display_desc:sub(1, last_space - 1)
@@ -919,7 +940,10 @@ function M:showCharacters()
         -- Aliases are no longer listed in the main character list to reduce clutter,
         -- as they are still visible in the individual character infobox.
         local char_desc = self:resolveDescriptionForPage(char)
-        if char_desc and #char_desc > 0 and char_desc ~= "---" then text = text .. "\n  " .. char_desc:sub(1, 80) .. (#char_desc > 80 and "..." or "") end
+        if char_desc and #char_desc > 0 and char_desc ~= "---" then
+            local safe_desc, is_truncated = _getTruncatedText(char_desc, 80)
+            text = text .. "\n  " .. safe_desc .. (is_truncated and "..." or "")
+        end
         table.insert(items, { 
             text = text, 
             keep_menu_open = true,
@@ -1234,9 +1258,8 @@ function M:showCharacterDetails(character, opts)
     local display_desc = resolved_desc
     local is_truncated = false
     if resolved_desc and resolved_desc ~= "" and resolved_desc ~= "---" then
-        if #resolved_desc > 500 then
-            is_truncated = true
-            display_desc = resolved_desc:sub(1, 450)
+        display_desc, is_truncated = _getTruncatedText(resolved_desc, 450, 500)
+        if is_truncated then
             local last_space = display_desc:match("^.*()%s")
             if last_space then
                 display_desc = display_desc:sub(1, last_space - 1)
@@ -1418,9 +1441,8 @@ function M:showLocationDetails(loc_item, opts)
     local display_desc = desc
     local is_truncated = false
     if desc and desc ~= "" then
-        if #desc > 500 then
-            is_truncated = true
-            display_desc = desc:sub(1, 450)
+        display_desc, is_truncated = _getTruncatedText(desc, 450, 500)
+        if is_truncated then
             local last_space = display_desc:match("^.*()%s")
             if last_space then
                 display_desc = display_desc:sub(1, last_space - 1)
@@ -1630,9 +1652,8 @@ function M:showTermDetails(term, opts)
     local display_definition = resolved_definition
     local is_truncated = false
     if resolved_definition and resolved_definition ~= "" and resolved_definition ~= "---" then
-        if #resolved_definition > 500 then
-            is_truncated = true
-            display_definition = resolved_definition:sub(1, 450)
+        display_definition, is_truncated = _getTruncatedText(resolved_definition, 450, 500)
+        if is_truncated then
             local last_space = display_definition:match("^.*()%s")
             if last_space then
                 display_definition = display_definition:sub(1, last_space - 1)
@@ -1668,10 +1689,11 @@ function M:showTermDetails(term, opts)
     local mentions_enabled = self.ai_helper and self.ai_helper.settings and self.ai_helper.settings.mentions_enabled ~= false
 
     local function get_relookup_row()
+        local safe_text = _getTruncatedText(opts.original_text, 30)
         return {
             {
-                text = self.loc:t("relookup_button", opts.original_text:sub(1, 30))
-                    or ("Re-lookup '" .. opts.original_text:sub(1, 30) .. "'"),
+                text = self.loc:t("relookup_button", safe_text)
+                    or ("Re-lookup '" .. safe_text .. "'"),
                 callback = function()
                     if self.active_details_dialog then UIManager:close(self.active_details_dialog); self.active_details_dialog = nil end
                     self:fetchSingleWord(opts.original_text, opts.pos0, opts.pos1)
@@ -1819,7 +1841,7 @@ function M:showTerms()
             end
             table.insert(items, {
                 text = "• " .. name,
-                subtext = term.definition and term.definition:sub(1, 80) .. "...",
+                subtext = term.definition and _getTruncatedText(term.definition, 80) .. "...",
                 keep_menu_open = true,
                 separator = true,
                 callback = function()
@@ -3357,9 +3379,8 @@ function M:showTimelineEventDetails(ev, opts)
     local is_truncated = false
     local TRUNCATE_AT  = 300   -- chars before we add Read More
 
-    if #event_text > TRUNCATE_AT then
-        is_truncated  = true
-        display_text  = event_text:sub(1, TRUNCATE_AT)
+    display_text, is_truncated = _getTruncatedText(event_text, TRUNCATE_AT)
+    if is_truncated then
         local last_sp = display_text:match("^.*()%s")
         if last_sp then display_text = display_text:sub(1, last_sp - 1) end
         display_text  = display_text .. " ..."
@@ -3502,9 +3523,8 @@ function M:showHistoricalFigureDetails(fig, opts)
     local display_bio = bio
     local is_truncated = false
     if bio and bio ~= "" then
-        if #bio > 500 then
-            is_truncated = true
-            display_bio = bio:sub(1, 450)
+        display_bio, is_truncated = _getTruncatedText(bio, 450, 500)
+        if is_truncated then
             local last_space = display_bio:match("^.*()%s")
             if last_space then
                 display_bio = display_bio:sub(1, last_space - 1)

--- a/xray.koplugin/xray_ui.lua
+++ b/xray.koplugin/xray_ui.lua
@@ -1826,9 +1826,15 @@ function M:showTerms()
             if term.source == "series_prior" then
                 name = name .. " " .. (self.loc:t("series_prior_label") or "[Prior]")
             end
+            local subtext = nil
+            if term.definition then
+                local trunc_text, is_trunc = _getTruncatedText(term.definition, 80)
+                subtext = trunc_text .. (is_trunc and "..." or "")
+            end
+
             table.insert(items, {
                 text = "• " .. name,
-                subtext = term.definition and _getTruncatedText(term.definition, 80) .. "...",
+                subtext = subtext,
                 keep_menu_open = true,
                 separator = true,
                 callback = function()

--- a/xray.koplugin/xray_ui.lua
+++ b/xray.koplugin/xray_ui.lua
@@ -27,6 +27,7 @@ local _ = gettext
 local plugin_path = ((...) or ""):match("(.-)[^%.]+$") or ""
 local xray_units = require(plugin_path .. "xray_units")
 local XRaySettingsCard = require(plugin_path .. "xray_settings_card")
+local utils = require(plugin_path .. "xray_utils")
 
 local M = {}
 
@@ -52,28 +53,14 @@ local DEFAULT_POPUP_FONT_SIZE = 22
 
 -- Returns true if the text contains CJK characters (U+3000–U+9FFF, etc.)
 local function _textHasCJK(text)
-    if type(text) ~= "string" then return false end
-    return text:find("[\227-\234][\128-\191][\128-\191]") ~= nil
+    return utils:textHasCJK(text)
 end
 
 -- Truncates a string to limit_en characters (scaled down to limit_en/3 if CJK)
 -- only if the total length exceeds threshold_en (scaled down to threshold_en/3 if CJK).
 -- Returns: truncated_text, is_truncated
 local function _getTruncatedText(text, limit_en, threshold_en)
-    if type(text) ~= "string" or text == "" then
-        return "", false
-    end
-    local is_cjk = _textHasCJK(text)
-    
-    local limit = is_cjk and math.floor(limit_en / 3) or limit_en
-    local threshold = is_cjk and math.floor((threshold_en or limit_en) / 3) or (threshold_en or limit_en)
-    
-    local chars = util.splitToChars(text)
-    if #chars > threshold then
-        return table.concat(chars, "", 1, limit), true
-    else
-        return text, false
-    end
+    return utils:getTruncatedText(text, limit_en, threshold_en)
 end
 
 

--- a/xray.koplugin/xray_utils.lua
+++ b/xray.koplugin/xray_utils.lua
@@ -90,4 +90,32 @@ function M:getFriendlyError(error_code, error_msg, loc)
     return loc:t(title_key), loc:t(desc_key, desc_arg)
 end
 
+-- Returns true if the text contains CJK characters (U+3000–U+9FFF, etc.)
+function M:textHasCJK(text)
+    if type(text) ~= "string" then return false end
+    return text:find("[\227-\234][\128-\191][\128-\191]") ~= nil
+end
+
+-- Truncates a string to limit_en characters (scaled down to limit_en/3 if CJK)
+-- only if the total length exceeds threshold_en (scaled down to threshold_en/3 if CJK).
+-- Returns: truncated_text, is_truncated
+function M:getTruncatedText(text, limit_en, threshold_en)
+    if type(text) ~= "string" or text == "" then
+        return "", false
+    end
+    local is_cjk = self:textHasCJK(text)
+    
+    local limit = is_cjk and math.floor(limit_en / 2) or limit_en
+    local threshold = is_cjk and math.floor((threshold_en or limit_en) / 2) or (threshold_en or limit_en)
+    
+    local util = require("util")
+    local chars = util.splitToChars(text)
+    if #chars > threshold then
+        return table.concat(chars, "", 1, limit), true
+    else
+        return text, false
+    end
+end
+
 return M
+

--- a/xray.koplugin/xray_utils.lua
+++ b/xray.koplugin/xray_utils.lua
@@ -1,5 +1,6 @@
 -- X-Ray Utility Functions
 local Device = require("device")
+local util = require("util")
 
 local M = {}
 
@@ -108,7 +109,6 @@ function M:getTruncatedText(text, limit_en, threshold_en)
     local limit = is_cjk and math.floor(limit_en / 2) or limit_en
     local threshold = is_cjk and math.floor((threshold_en or limit_en) / 2) or (threshold_en or limit_en)
     
-    local util = require("util")
     local chars = util.splitToChars(text)
     if #chars > threshold then
         return table.concat(chars, "", 1, limit), true


### PR DESCRIPTION
… translation

Problems:
1. CJK character lookup normalization: The alphanumeric-only stripping regex in `LookupManager:normalize` stripped CJK name strings completely or removed valid leading/trailing characters, causing name lookups to fail for CJK characters.
2. UTF-8 truncation corruption: Several byte-based `string.sub` truncation calls sliced inside multi-byte UTF-8 CJK characters, leading to corrupted text ending in question marks ("?") across character lists, details boxes, and timeline menus.
3. Untranslated CJK label: The "label_aliases" key in the Simplified Chinese locale was set to the placeholder string "??".

Fixes:
1. Selective Lookup Normalization: Modified `LookupManager:normalize` to apply the strict alphanumeric-only filter only to English/ASCII strings. For CJK/multilingual text, a punctuation-only filter is used, preserving CJK characters.
2. Native KOReader UTF-8 Truncation: Refactored `xray_ui.lua` to route all 9 truncation locations through a unified `_getTruncatedText` helper. The helper splits strings using KOReader's native `util.splitToChars(text)` to count and slice text safely on character boundaries, avoiding byte-slicing errors and invalid tail sequences.
3. CJK scaling and buffer logic: Programmed the helper to scale down character limits and check thresholds by 3 if CJK characters are detected. It supports a separate check threshold (e.g., 450 limit, 500 threshold) to preserve the original design's buffer zone.
4. Translation fix: Updated the "label_aliases" translation to "别名" in `zh_CN.po` and ran `sync_translations.py -m skip` to synchronize the catalog structures.