### PR TITLE
Fix custom API slot sending placeholder model name (fixes #86)

### DIFF
--- a/spec/xray_aihelper_spec.lua
+++ b/spec/xray_aihelper_spec.lua
@@ -149,6 +149,112 @@ describe("AIHelper", function()
         end)
     end)
 
+    describe("custom slot model resolution (issue #86)", function()
+        local saved_custom1
+
+        before_each(function()
+            saved_custom1 = {
+                api_key = AIHelper.providers.custom1.api_key,
+                endpoint = AIHelper.providers.custom1.endpoint,
+                model = AIHelper.providers.custom1.model,
+                format = AIHelper.providers.custom1.format,
+            }
+            AIHelper.providers.custom1.api_key = "sk-or-test"
+            AIHelper.providers.custom1.endpoint = "https://openrouter.ai/api/v1/chat/completions"
+            AIHelper.providers.custom1.model = "deepseek/deepseek-v4-flash"
+            AIHelper.providers.custom1.format = nil
+        end)
+
+        after_each(function()
+            AIHelper.providers.custom1.api_key = saved_custom1.api_key
+            AIHelper.providers.custom1.endpoint = saved_custom1.endpoint
+            AIHelper.providers.custom1.model = saved_custom1.model
+            AIHelper.providers.custom1.format = saved_custom1.format
+        end)
+
+        describe("resolveModel", function()
+            it("passes through explicit model names", function()
+                assert.are.equal("mistral/mistral-large", AIHelper:resolveModel("custom1", "mistral/mistral-large"))
+                assert.are.equal("gpt-4o", AIHelper:resolveModel("chatgpt", "gpt-4o"))
+            end)
+
+            it("replaces the slot-name placeholder with the configured model", function()
+                assert.are.equal("deepseek/deepseek-v4-flash", AIHelper:resolveModel("custom1", "custom1"))
+            end)
+
+            it("falls back to the configured model when no model is given", function()
+                assert.are.equal("deepseek/deepseek-v4-flash", AIHelper:resolveModel("custom1", nil))
+            end)
+
+            it("returns nil when the slot has no configured model", function()
+                AIHelper.providers.custom1.model = ""
+                assert.is_nil(AIHelper:resolveModel("custom1", "custom1"))
+            end)
+        end)
+
+        describe("buildComprehensiveRequest with placeholder model", function()
+            before_each(function()
+                AIHelper.settings = {
+                    primary_ai = { provider = "custom1", model = "custom1" },
+                    secondary_ai = { provider = "custom1", model = "custom1" },
+                }
+            end)
+
+            it("sends the configured model instead of the placeholder", function()
+                local requests = AIHelper:buildComprehensiveRequest("Title", "Author", {})
+                local body = require("json").decode(requests[1].body)
+                assert.are.equal("deepseek/deepseek-v4-flash", body.model)
+            end)
+
+            it("uses the documented X-Title header for OpenRouter attribution", function()
+                local requests = AIHelper:buildComprehensiveRequest("Title", "Author", {})
+                assert.is_not_nil(requests[1].headers["HTTP-Referer"])
+                assert.are.equal("KOReader X-Ray", requests[1].headers["X-Title"])
+                assert.is_nil(requests[1].headers["X-OpenRouter-Title"])
+            end)
+        end)
+
+        describe("loadSettings placeholder repair", function()
+            it("replaces a stored placeholder model with the slot's configured model", function()
+                local old_open = io.open
+                io.open = function(path, mode)
+                    if path:find("settings.json") then
+                        return {
+                            read = function(self, fmt)
+                                return '{"primary_ai": {"provider": "custom1", "model": "custom1"}, "custom1_model": "deepseek/deepseek-v4-flash", "ui_defaults_migrated_v2": true}'
+                            end,
+                            close = function() end
+                        }
+                    end
+                    return old_open(path, mode)
+                end
+                local old_save = AIHelper.saveSettings
+                AIHelper.saveSettings = function() end
+
+                AIHelper:loadSettings()
+
+                io.open = old_open
+                AIHelper.saveSettings = old_save
+
+                assert.are.equal("deepseek/deepseek-v4-flash", AIHelper.settings.primary_ai.model)
+            end)
+        end)
+
+        describe("checkAsyncResult error reporting", function()
+            it("includes the provider's error message on non-200 responses", function()
+                local tmp = os.tmpname()
+                local f = io.open(tmp, "w")
+                f:write('400\ncustom1\n{"error":{"message":"custom1 is not a valid model ID","code":400}}')
+                f:close()
+
+                local data, err_code, err_msg = AIHelper:checkAsyncResult(tmp)
+                assert.is_false(data)
+                assert.are.equal("error_api", err_code)
+                assert.are.equal("HTTP 400: custom1 is not a valid model ID", err_msg)
+            end)
+        end)
+    end)
+
     describe("isAnthropic", function()
         it("should return true for claude provider", function()
             assert.is_true(AIHelper:isAnthropic("claude", nil))

--- a/spec/xray_utils_spec.lua
+++ b/spec/xray_utils_spec.lua
@@ -91,10 +91,12 @@ describe("xray_utils", function()
             assert.are.equal("error_model_not_found_desc", desc)
         end)
 
-        it("maps 400 API error to invalid api key", function()
-            local title, desc = utils:getFriendlyError("error_api", "HTTP 400: Bad Request", loc)
-            assert.are.equal("error_api_key_title", title)
-            assert.are.equal("error_api_key_desc", desc)
+        it("surfaces 400 API error details instead of blaming the API key", function()
+            -- Issue #86: a 400 is a malformed/rejected request (e.g. invalid
+            -- model name), not an authentication failure. Show the detail.
+            local title, desc = utils:getFriendlyError("error_api", "HTTP 400: custom1 is not a valid model ID", loc)
+            assert.are.equal("error_unknown_title", title)
+            assert.are.equal("error_unknown_desc:HTTP 400: custom1 is not a valid model ID", desc)
         end)
 
         it("handles unknown errors by returning the raw message", function()

--- a/xray.koplugin/xray_aihelper.lua
+++ b/xray.koplugin/xray_aihelper.lua
@@ -168,6 +168,30 @@ function AIHelper:getChatGPTTokenConfig(model)
     return "max_tokens", 16384
 end
 
+-- Resolve the effective model name for a request.
+-- The model picker historically stored the slot name ("custom1"/"custom2") as a
+-- placeholder model when the slot's model was configured in xray_config.lua
+-- rather than through the API Keys UI. Never send that placeholder to the API:
+-- fall back to the slot's configured model instead (issue #86).
+function AIHelper:resolveModel(provider_id, model)
+    if model == "" then model = nil end
+    if provider_id == "custom1" or provider_id == "custom2" then
+        if not model or model == provider_id then
+            local slot = self.providers[provider_id]
+            local slot_model = slot and slot.model
+            if slot_model and slot_model ~= "" then
+                return slot_model
+            end
+            if model then
+                self:log("AIHelper: WARNING: no model configured for " .. provider_id
+                    .. " (set " .. provider_id .. "_model in xray_config.lua or the API Keys menu)")
+                return nil
+            end
+        end
+    end
+    return model
+end
+
 function AIHelper:setTrapWidget(trap_widget) self.trap_widget = trap_widget end
 function AIHelper:resetTrapWidget() self.trap_widget = nil end
 
@@ -214,8 +238,9 @@ function AIHelper:buildComprehensiveRequest(title, author, context, prompt_overr
         local config = self.providers[ai.provider]
         if config and config.api_key and config.api_key ~= "" then
             local url, headers, body
+            local resolved_model = self:resolveModel(ai.provider, ai.model)
             if ai.provider == "gemini" then
-                local model = ai.model or DEFAULT_AI.primary.model
+                local model = resolved_model or DEFAULT_AI.primary.model
                 local system_instruction_text = self.prompts and self.prompts.system_instruction or "Return valid JSON ONLY."
                 url = "https://generativelanguage.googleapis.com/v1beta/models/" .. model .. ":generateContent"
                 headers = { ["Content-Type"] = "application/json", ["x-goog-api-key"] = config.api_key }
@@ -267,7 +292,7 @@ function AIHelper:buildComprehensiveRequest(title, author, context, prompt_overr
                     generationConfig = gen_config
                 })
             elseif self:isAnthropic(ai.provider, config.endpoint) then
-                local model = ai.model or "claude-3-7-sonnet-latest"
+                local model = resolved_model or "claude-3-7-sonnet-latest"
                 url = config.endpoint or "https://api.anthropic.com/v1/messages"
                 headers = {
                     ["Content-Type"] = "application/json",
@@ -283,7 +308,7 @@ function AIHelper:buildComprehensiveRequest(title, author, context, prompt_overr
                 if ai.provider == "custom1" or ai.provider == "custom2" then
                     if (config.endpoint or ""):find("openrouter.ai") then
                         headers["HTTP-Referer"]      = "https://github.com/koreader/koreader-xray-plugin"
-                        headers["X-OpenRouter-Title"] = "KOReader X-Ray"
+                        headers["X-Title"] = "KOReader X-Ray"
                     end
                 end
                 
@@ -329,7 +354,7 @@ function AIHelper:buildComprehensiveRequest(title, author, context, prompt_overr
                 
                 body = json.encode(req_body)
             else
-                local model = ai.model or "gpt-4o-mini"
+                local model = resolved_model or "gpt-4o-mini"
                 url = config.endpoint or "https://api.openai.com/v1/chat/completions"
                 headers = { ["Content-Type"] = "application/json", ["Authorization"] = "Bearer " .. config.api_key }
                 local system_instruction_text = self.prompts and self.prompts.system_instruction or "Return valid JSON ONLY."
@@ -388,7 +413,7 @@ function AIHelper:buildComprehensiveRequest(title, author, context, prompt_overr
                 if ai.provider == "custom1" or ai.provider == "custom2" then
                     if (config.endpoint or ""):find("openrouter.ai") then
                         headers["HTTP-Referer"]      = "https://github.com/koreader/koreader-xray-plugin"
-                        headers["X-OpenRouter-Title"] = "KOReader X-Ray"
+                        headers["X-Title"] = "KOReader X-Ray"
                     end
                     -- Per-slot "Is Reasoning Model" setting: raise token ceiling to accommodate reasoning chains
                     local is_reasoning = self.settings and self.settings[ai.provider .. "_is_reasoning"]
@@ -400,7 +425,7 @@ function AIHelper:buildComprehensiveRequest(title, author, context, prompt_overr
                 
                 body = json.encode(req_body)
             end
-            table.insert(requests, { url = url, headers = headers, body = body, provider = ai.provider, model = ai.model })
+            table.insert(requests, { url = url, headers = headers, body = body, provider = ai.provider, model = resolved_model or ai.model })
         end
     end
     
@@ -630,6 +655,9 @@ function AIHelper:makeRequestAsync(request_params, result_file)
                     end
                 else
                     self:log(string.format("AIHelper Child: Provider %s failed with code %s", req.provider, tostring(code)))
+                    if response_text and #response_text > 0 then
+                        self:log("AIHelper Child: Error response: " .. response_text:sub(1, 500))
+                    end
                     -- If it's the last one, write the error
                     if i == #requests then
                         local f = io.open(result_file, "w")
@@ -773,7 +801,17 @@ function AIHelper:checkAsyncResult(result_file)
 
     local code_num = tonumber(code_str)
     if code_num ~= 200 or not response_text or #response_text == 0 then
-        return false, "error_api", "HTTP " .. tostring(code_num)
+        -- Surface the provider's own error message (Gemini/OpenAI/OpenRouter/
+        -- Anthropic all use {"error": {"message": ...}}), so failures like an
+        -- invalid model name are not misreported as API key problems.
+        local error_detail = "HTTP " .. tostring(code_num)
+        if response_text and #response_text > 0 then
+            local s, err_data = pcall(json.decode, response_text)
+            if s and type(err_data) == "table" and type(err_data.error) == "table" and err_data.error.message then
+                error_detail = error_detail .. ": " .. tostring(err_data.error.message)
+            end
+        end
+        return false, "error_api", error_detail
     end
 
     -- Parse the response based on provider
@@ -1132,7 +1170,29 @@ function AIHelper:loadSettings()
         if settings[slot .. "_model"] then self.providers[slot].model = settings[slot .. "_model"] end
         if settings[slot .. "_format"] then self.providers[slot].format = settings[slot .. "_format"] end
     end
-    
+
+    -- Repair placeholder model names stored by older versions of the model picker:
+    -- selecting "Custom API 1/2" with the model configured only in xray_config.lua
+    -- saved the slot name itself as the model (issue #86). Must run after the
+    -- custom slot loop above so providers[slot].model holds the merged value.
+    local placeholder_repaired = false
+    for _, ai_slot in ipairs({"primary_ai", "secondary_ai"}) do
+        local ai = settings[ai_slot]
+        if type(ai) == "table" and (ai.provider == "custom1" or ai.provider == "custom2")
+            and (ai.model == nil or ai.model == "" or ai.model == ai.provider) then
+            local slot_model = self.providers[ai.provider] and self.providers[ai.provider].model
+            if slot_model and slot_model ~= "" and ai.model ~= slot_model then
+                self:log(string.format("AIHelper: Replacing %s placeholder model '%s' with configured '%s'",
+                    ai_slot, tostring(ai.model), slot_model))
+                ai.model = slot_model
+                placeholder_repaired = true
+            end
+        end
+    end
+    if placeholder_repaired then
+        self:saveSettings()
+    end
+
     self:loadLanguage()
 end
 
@@ -1475,19 +1535,20 @@ function AIHelper:executeUnifiedRequest(prompt)
     for _, ai in ipairs(models_to_try) do
         local config = self.providers[ai.provider]
         if not config or not config.api_key or config.api_key == "" then
-            self:log("AIHelper: Skipping " .. ai.provider .. " (" .. ai.model .. ") - API Key missing")
+            self:log("AIHelper: Skipping " .. ai.provider .. " (" .. tostring(ai.model) .. ") - API Key missing")
             last_err = "API Key not set for " .. (ai.provider == "gemini" and "Google Gemini" or "ChatGPT")
         else
-            self:log("AIHelper: Trying unified fallback model: " .. ai.provider .. " / " .. ai.model)
+            local model = self:resolveModel(ai.provider, ai.model)
+            self:log("AIHelper: Trying unified fallback model: " .. ai.provider .. " / " .. tostring(model))
             local result, err_code, err_msg
             if ai.provider == "gemini" then
-                result, err_code, err_msg = self:callGemini(prompt, config, ai.model)
+                result, err_code, err_msg = self:callGemini(prompt, config, model)
             elseif self:isAnthropic(ai.provider, config.endpoint) then
-                result, err_code, err_msg = self:callClaude(prompt, config, ai.model or config.model)
+                result, err_code, err_msg = self:callClaude(prompt, config, model)
             elseif ai.provider == "custom1" or ai.provider == "custom2" then
-                result, err_code, err_msg = self:callChatGPT(prompt, config, ai.model or config.model)
+                result, err_code, err_msg = self:callChatGPT(prompt, config, model)
             else
-                result, err_code, err_msg = self:callChatGPT(prompt, config, ai.model)
+                result, err_code, err_msg = self:callChatGPT(prompt, config, model)
             end
             
             if result then return result end
@@ -1623,7 +1684,7 @@ function AIHelper:callClaude(prompt, config, current_model)
     if provider_id and (provider_id == "custom1" or provider_id == "custom2") then
         if (config.endpoint or ""):find("openrouter.ai") then
             headers["HTTP-Referer"]       = "https://github.com/koreader/koreader-xray-plugin"
-            headers["X-OpenRouter-Title"] = "KOReader X-Ray"
+            headers["X-Title"] = "KOReader X-Ray"
         end
     end
     
@@ -1783,7 +1844,7 @@ function AIHelper:callChatGPT(prompt, config, current_model)
     local headers = { ["Content-Type"] = "application/json", ["Authorization"] = "Bearer " .. config.api_key }
     if (config.endpoint or ""):find("openrouter.ai") then
         headers["HTTP-Referer"]       = "https://github.com/koreader/koreader-xray-plugin"
-        headers["X-OpenRouter-Title"] = "KOReader X-Ray"
+        headers["X-Title"] = "KOReader X-Ray"
     end
     
     local ok, code, response_text = self:makeRequest(config.endpoint or "https://api.openai.com/v1/chat/completions", headers, request_body)

--- a/xray.koplugin/xray_ui.lua
+++ b/xray.koplugin/xray_ui.lua
@@ -3897,8 +3897,19 @@ function M:getAIModelSelectionMenu(setting_type)
         }
     }
     
-    local custom1_model = (self.ai_helper and self.ai_helper.settings) and self.ai_helper.settings.custom1_model or nil
-    local custom2_model = (self.ai_helper and self.ai_helper.settings) and self.ai_helper.settings.custom2_model or nil
+    -- Prefer the merged provider config: it covers models configured via
+    -- xray_config.lua, not only those entered in the API Keys UI (issue #86).
+    local function getCustomSlotModel(slot)
+        local model = self.ai_helper and self.ai_helper.providers
+            and self.ai_helper.providers[slot] and self.ai_helper.providers[slot].model
+        if not model or model == "" then
+            model = self.ai_helper and self.ai_helper.settings and self.ai_helper.settings[slot .. "_model"]
+        end
+        if model == "" then model = nil end
+        return model
+    end
+    local custom1_model = getCustomSlotModel("custom1")
+    local custom2_model = getCustomSlotModel("custom2")
     
     local menu_items = {}
     

--- a/xray.koplugin/xray_utils.lua
+++ b/xray.koplugin/xray_utils.lua
@@ -64,7 +64,7 @@ function M:getFriendlyError(error_code, error_msg, loc)
         desc_arg = nil
     elseif error_code == "error_api" then
         local msg = tostring(error_msg or ""):lower()
-        if msg:find("401") or msg:find("unauthorized") or msg:find("invalid api key") or msg:find("400") or msg:find("bad request") then
+        if msg:find("401") or msg:find("unauthorized") or msg:find("invalid api key") then
             title_key = "error_api_key_title"
             desc_key = "error_api_key_desc"
             desc_arg = nil


### PR DESCRIPTION
## Summary

Fixes #86 — custom API slots (OpenRouter and other OpenAI-compatible endpoints) failed with HTTP 400 despite a valid API key.

### Root cause

When a custom slot's model is configured in `xray_config.lua` rather than through the API Keys UI, the model picker menu only looked at `settings.custom1_model` (the UI-entered value), found nothing, and stored the literal slot name as the model: `primary_ai = { provider = "custom1", model = "custom1" }`. Requests then went out with `"model": "custom1"`, which OpenRouter rejects:

```
HTTP 400 {"error":{"message":"custom1 is not a valid model ID","code":400}}
```

The log line from the issue shows it: `Sending request 1/1 to custom1 (custom1)` — the value in parentheses is the model field.

Two further bugs made this look like an authentication problem:
- `checkAsyncResult` discarded the error response body and reported only `HTTP 400`.
- `getFriendlyError` mapped any HTTP 400 to "Invalid API Key".

### Changes

- **`AIHelper:resolveModel()`** — new helper used by all request builders (`buildComprehensiveRequest`, `executeUnifiedRequest`); the slot-name placeholder is never sent and resolves to the slot's configured model instead.
- **Settings repair** — `loadSettings` replaces an already-persisted placeholder model with the slot's configured model, so affected installs fix themselves on restart with no user action.
- **Model picker** — the "Custom API 1/2" menu entries now fall back to the merged provider config, so models configured via `xray_config.lua` are displayed and stored correctly.
- **Error surfacing** — the background child logs the error response body (truncated to 500 chars), and `checkAsyncResult` extracts `error.message` from non-200 responses (all supported providers use the `{"error":{"message":...}}` shape).
- **`getFriendlyError`** — HTTP 400 no longer claims a bad API key; the actual error detail is shown.
- **Drive-by** — OpenRouter attribution header corrected to the documented `X-Title` (was `X-OpenRouter-Title`).

### Testing

- Spec suite: **199/199 pass** (9 new regression tests: `resolveModel` behavior, request building with a placeholder model, the `loadSettings` repair, `checkAsyncResult` error extraction, `X-Title` header, and the updated 400 mapping).
- Live verification against OpenRouter with a real key, using request bodies generated by the plugin's own request builder:
  - old body (`"model": "custom1"`) → reproduces the exact HTTP 400 from the issue;
  - fixed body (`"model": "deepseek/deepseek-v4-flash"`) → HTTP 200 with valid JSON matching the X-Ray schema.
- Confirmed end-to-end on a Kobo device with the book from the issue report: startup log shows the settings repair, fetch succeeds with code 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)