### PR TITLE
fix: keep PDF X-Ray context within current page

### DIFF
--- a/spec/xray_chapteranalyzer_spec.lua
+++ b/spec/xray_chapteranalyzer_spec.lua
@@ -3,6 +3,20 @@ require("spec.spec_helper")
 local analyzer = require("xray_chapteranalyzer")
 
 describe("xray_chapteranalyzer", function()
+    describe("getEndPageForCurrentPage", function()
+        it("uses the next page as the end XPointer for reflowable documents", function()
+            local ui = { rolling = {} }
+
+            assert.are.equal(26, analyzer:getEndPageForCurrentPage(ui, 25))
+        end)
+
+        it("uses the current page as the inclusive end for page-based documents", function()
+            local ui = { paging = {} }
+
+            assert.are.equal(25, analyzer:getEndPageForCurrentPage(ui, 25))
+        end)
+    end)
+
     describe("countMentions", function()
         it("counts exact mentions correctly", function()
             local text = "Alice went to the park. Alice saw a bird."
@@ -128,6 +142,28 @@ describe("xray_chapteranalyzer", function()
             assert.are.equal("xp_page_80", getTextFromXPointers_calls[1].end_xp)
             assert.are.equal("some mock text extracted", text)
         end)
+
+        it("does not extract the next page from a page-based document", function()
+            local getPageText_calls = {}
+            local paged_ui = {
+                paging = {},
+                document = {
+                    getPageText = function(self, page)
+                        table.insert(getPageText_calls, page)
+                        return "text from page " .. page
+                    end,
+                },
+            }
+            local current_page = 25
+            local end_page = analyzer:getEndPageForCurrentPage(paged_ui, current_page)
+
+            local text = analyzer:getTextForAnalysis(paged_ui, 50000, nil, end_page, 20)
+
+            assert.are.equal(6, #getPageText_calls)
+            assert.are.equal(20, getPageText_calls[1])
+            assert.are.equal(25, getPageText_calls[#getPageText_calls])
+            assert.is_nil(text:find("text from page 26", 1, true))
+        end)
     end)
 
     describe("getDetailedChapterSamples", function()
@@ -189,6 +225,39 @@ describe("xray_chapteranalyzer", function()
             assert.are.equal("xp_page_26", getTextFromXPointers_calls[1].end_xp)
         end)
 
+        it("spoiler-free mode does not sample beyond the current PDF page", function()
+            local getPageText_calls = {}
+            local paged_ui = {
+                paging = {},
+                document = {
+                    getToc = function()
+                        return {
+                            { title = "Chapter 1", page = 20, xpointer = "page:20" },
+                            { title = "Chapter 2", page = 40, xpointer = "page:40" },
+                        }
+                    end,
+                    getPageText = function(self, page)
+                        table.insert(getPageText_calls, page)
+                        return string.rep("page " .. page .. " text ", 20)
+                    end,
+                },
+                view = {
+                    state = { page = 25 },
+                },
+            }
+
+            local samples, titles = analyzer:getDetailedChapterSamples(paged_ui, 100, 60000, false)
+
+            assert.is_not_nil(samples)
+            assert.are.equal(1, #titles)
+            assert.are.equal("Chapter 1", titles[1])
+            assert.are.equal(20, getPageText_calls[1])
+            assert.are.equal(25, getPageText_calls[#getPageText_calls])
+            for _, page in ipairs(getPageText_calls) do
+                assert.is_true(page <= 25)
+            end
+        end)
+
         it("spoiler-free mode limits NO TOC fallback range to current page", function()
             -- Mock no TOC
             mock_ui.document.getToc = function() return nil end
@@ -233,4 +302,3 @@ describe("xray_chapteranalyzer", function()
         end)
     end)
 end)
-

--- a/xray.koplugin/xray_chapteranalyzer.lua
+++ b/xray.koplugin/xray_chapteranalyzer.lua
@@ -32,6 +32,18 @@ function ChapterAnalyzer:new(o)
     return o
 end
 
+-- Page ranges use different end semantics across KOReader document types.
+-- Reflowable extraction stops at the end XPointer, so the next page marks the
+-- end of the current page. Page-based extraction is inclusive and must stop on
+-- the current page to avoid reading one page ahead.
+function ChapterAnalyzer:getEndPageForCurrentPage(ui, current_page)
+    if not current_page then return nil end
+    if ui and ui.rolling ~= nil then
+        return current_page + 1
+    end
+    return current_page
+end
+
 -- Get current chapter/section text
 function ChapterAnalyzer:getCurrentChapterText(ui)
     if not ui or not ui.document then
@@ -791,7 +803,8 @@ function ChapterAnalyzer:getDetailedChapterSamples(ui, max_chapters, total_limit
 
             local success, chapter_text = pcall(function()
                 if is_current_chapter then
-                    return self:getTextFromPageRange(ui, chapter.page, current_page + 1, total_limit)
+                    local end_page = self:getEndPageForCurrentPage(ui, current_page)
+                    return self:getTextFromPageRange(ui, chapter.page, end_page, total_limit)
                 elseif ui.document.getTextFromXPointer and chapter.xpointer then
                     -- EPUB: Usually returns the full text of the chapter file
                     return ui.document:getTextFromXPointer(chapter.xpointer)

--- a/xray.koplugin/xray_fetch.lua
+++ b/xray.koplugin/xray_fetch.lua
@@ -93,7 +93,7 @@ function M:fetchSingleWord(text, pos0, pos1)
             progress_msg:reportProgress(30)
             
             -- 2. Immediate book text (Previous and Current page for maximum context relevance)
-            local end_page = current_page + 1
+            local end_page = self.chapter_analyzer:getEndPageForCurrentPage(self.ui, current_page)
             local book_text = self.chapter_analyzer:getTextFromPageRange(self.ui, math.max(1, current_page - 1), end_page, 25000)
             
             local context_prefix = "SEARCH TARGET: \"" .. text .. "\"\n"
@@ -415,7 +415,7 @@ function M:continueWithFetch(reading_percent, is_update, last_fetch_page, is_sil
         local end_page_analysis = current_page
         local spoiler_setting = self.ai_helper and self.ai_helper.settings and self.ai_helper.settings.spoiler_setting or "spoiler_free"
         if spoiler_setting ~= "full_book" then
-            end_page_analysis = current_page + 1
+            end_page_analysis = self.chapter_analyzer:getEndPageForCurrentPage(self.ui, current_page)
         end
         local book_text = self.chapter_analyzer:getTextForAnalysis(self.ui, 20000, nil, end_page_analysis, first_missing_page)
         local known_chapters = {}


### PR DESCRIPTION
Hey, it's me again :) Found this while looking at the code earlier.

PDF page ranges are inclusive, so spoiler-free extraction using current_page + 1 also sent the next page to the AI. The spoiler risk is limited to that single page, but the extraction boundary should still match the reader’s actual position. 

This PR fixes the above problem by making page boundaries format-aware.