### PR TITLE
fix: cancel active AI requests

### DIFF
--- a/spec/xray_aihelper_spec.lua
+++ b/spec/xray_aihelper_spec.lua
@@ -211,6 +211,25 @@ describe("AIHelper", function()
                 assert.is_not_nil(requests[1].headers["HTTP-Referer"])
                 assert.are.equal("KOReader X-Ray", requests[1].headers["X-Title"])
                 assert.is_nil(requests[1].headers["X-OpenRouter-Title"])
+                assert.are.equal("text/event-stream", requests[1].headers["Accept"])
+                assert.are.equal("openai", requests[1].stream_format)
+                assert.is_true(require("json").decode(requests[1].body).stream)
+            end)
+
+            it("does not enable streaming for other custom endpoints", function()
+                AIHelper.providers.custom1.endpoint = "https://example.com/v1/chat/completions"
+                local requests = AIHelper:buildComprehensiveRequest("Title", "Author", {})
+                assert.is_nil(requests[1].stream_format)
+                assert.is_nil(require("json").decode(requests[1].body).stream)
+            end)
+
+            it("enables Anthropic streaming for OpenRouter Messages endpoints", function()
+                AIHelper.providers.custom1.endpoint = "https://openrouter.ai/api/v1/messages"
+                AIHelper.providers.custom1.format = "anthropic"
+                local requests = AIHelper:buildComprehensiveRequest("Title", "Author", {})
+                assert.are.equal("anthropic", requests[1].stream_format)
+                assert.are.equal("text/event-stream", requests[1].headers["Accept"])
+                assert.is_true(require("json").decode(requests[1].body).stream)
             end)
         end)
 
@@ -254,6 +273,69 @@ describe("AIHelper", function()
             end)
         end)
 
+    end)
+
+    describe("OpenRouter stream normalization", function()
+        local json = require("json")
+
+        it("reconstructs an OpenAI-compatible streamed response", function()
+            local stream = table.concat({
+                ": OPENROUTER PROCESSING",
+                "data: " .. json.encode({ choices = {{ delta = { content = '{"characters":' } }} }),
+                "data: " .. json.encode({ choices = {{ delta = { content = "[]}" }, finish_reason = "stop" }} }),
+                "data: [DONE]",
+                "",
+            }, "\r\n")
+
+            local normalized = AIHelper:normalizeOpenRouterStream(stream, "openai")
+            assert.is_not_nil(normalized)
+            local response = json.decode(normalized)
+            assert.are.equal('{"characters":[]}', response.choices[1].message.content)
+        end)
+
+        it("reconstructs an Anthropic Messages streamed response", function()
+            local stream = table.concat({
+                "event: content_block_start",
+                "data: " .. json.encode({
+                    type = "content_block_start",
+                    content_block = { type = "text", text = '{"locations":' },
+                }),
+                "event: content_block_delta",
+                "data: " .. json.encode({
+                    type = "content_block_delta",
+                    delta = { type = "text_delta", text = "[]}" },
+                }),
+                "event: message_stop",
+                "data: " .. json.encode({ type = "message_stop" }),
+                "",
+            }, "\n")
+
+            local normalized = AIHelper:normalizeOpenRouterStream(stream, "anthropic")
+            assert.is_not_nil(normalized)
+            local response = json.decode(normalized)
+            assert.are.equal('{"locations":[]}', response.content[1].text)
+        end)
+
+        it("surfaces mid-stream provider errors", function()
+            local stream = "data: " .. json.encode({
+                error = { code = 502, message = "Provider disconnected" },
+                choices = {{ delta = { content = "" }, finish_reason = "error" }},
+            }) .. "\n"
+
+            local normalized, err = AIHelper:normalizeOpenRouterStream(stream, "openai")
+            assert.is_nil(normalized)
+            assert.are.equal("Provider disconnected", err)
+        end)
+
+        it("rejects incomplete streams instead of accepting partial output", function()
+            local stream = "data: " .. json.encode({
+                choices = {{ delta = { content = '{"characters":[]}' } }},
+            }) .. "\n"
+
+            local normalized, err = AIHelper:normalizeOpenRouterStream(stream, "openai")
+            assert.is_nil(normalized)
+            assert.are.equal("OpenRouter stream ended before completion", err)
+        end)
     end)
 
     describe("async child cancellation", function()

--- a/spec/xray_aihelper_spec.lua
+++ b/spec/xray_aihelper_spec.lua
@@ -257,22 +257,29 @@ describe("AIHelper", function()
     end)
 
     describe("async child cancellation", function()
-        it("terminates, reaps, and cleans only the expected child", function()
+        it("terminates immediately and reaps only the expected child in the background", function()
             local old_ffiutil = package.loaded["ffi/util"]
             local old_kill = AIHelper._killAsyncPID
+            local UIManager = require("ui/uimanager")
+            local old_schedule = UIManager.scheduleIn
             local calls = {}
+            local scheduled = {}
+            local reap_results = { false, false, true }
             package.loaded["ffi/util"] = {
                 terminateSubProcess = function(pid)
                     table.insert(calls, { action = "terminate", pid = pid })
                 end,
                 isSubProcessDone = function(pid, wait)
                     table.insert(calls, { action = "reap", pid = pid, wait = wait })
-                    return true
+                    return table.remove(reap_results, 1)
                 end,
             }
-            AIHelper._killAsyncPID = function(self, pid, wait)
-                table.insert(calls, { action = "kill", pid = pid, wait = wait })
+            AIHelper._killAsyncPID = function(self, pid)
+                table.insert(calls, { action = "kill", pid = pid })
                 return true
+            end
+            UIManager.scheduleIn = function(self, delay, callback)
+                table.insert(scheduled, callback)
             end
 
             local result_file = os.tmpname()
@@ -290,22 +297,36 @@ describe("AIHelper", function()
                 assert.are.equal(0, #calls)
 
                 assert.is_true(AIHelper:cancelAsyncChild(4321))
-                assert.are.equal("kill", calls[1].action)
+                assert.are.equal("terminate", calls[1].action)
+                assert.are.equal("kill", calls[2].action)
                 assert.are.equal(4321, calls[1].pid)
-                assert.is_false(calls[1].wait)
-                assert.are.equal("terminate", calls[2].action)
                 assert.are.equal("reap", calls[3].action)
-                assert.is_true(calls[3].wait)
+                assert.is_nil(calls[3].wait)
                 assert.is_nil(AIHelper._async_child_pid)
                 assert.is_nil(AIHelper._async_result_file)
                 assert.is_nil(io.open(result_file, "r"))
+                assert.are.equal(1, #scheduled)
+
+                table.remove(scheduled, 1)()
+                assert.are.equal("reap", calls[4].action)
+                assert.is_nil(calls[4].wait)
+                assert.are.equal(1, #scheduled)
+                assert.is_true(AIHelper._async_children_to_reap[4321])
+
+                table.remove(scheduled, 1)()
+                assert.are.equal("reap", calls[5].action)
+                assert.is_nil(calls[5].wait)
+                assert.is_nil(AIHelper._async_children_to_reap)
+                assert.are.equal(0, #scheduled)
             end)
 
             package.loaded["ffi/util"] = old_ffiutil
             AIHelper._killAsyncPID = old_kill
+            UIManager.scheduleIn = old_schedule
             AIHelper._async_child_pid = nil
             AIHelper._async_child_uses_process_group = nil
             AIHelper._async_result_file = nil
+            AIHelper._async_children_to_reap = nil
             pcall(function() os.remove(result_file) end)
             if not ok then error(err) end
         end)

--- a/spec/xray_aihelper_spec.lua
+++ b/spec/xray_aihelper_spec.lua
@@ -282,10 +282,12 @@ describe("AIHelper", function()
             local stream = table.concat({
                 ": OPENROUTER PROCESSING",
                 "data: " .. json.encode({ choices = {{ delta = { content = '{"characters":' } }} }),
+                "",
                 "data: " .. json.encode({ choices = {{ delta = { content = "[]}" }, finish_reason = "stop" }} }),
+                "",
                 "data: [DONE]",
                 "",
-            }, "\r\n")
+            }, "\r\n") .. "\r\n"
 
             local normalized = AIHelper:normalizeOpenRouterStream(stream, "openai")
             assert.is_not_nil(normalized)
@@ -300,20 +302,37 @@ describe("AIHelper", function()
                     type = "content_block_start",
                     content_block = { type = "text", text = '{"locations":' },
                 }),
+                "",
                 "event: content_block_delta",
                 "data: " .. json.encode({
                     type = "content_block_delta",
                     delta = { type = "text_delta", text = "[]}" },
                 }),
+                "",
                 "event: message_stop",
                 "data: " .. json.encode({ type = "message_stop" }),
                 "",
-            }, "\n")
+            }, "\n") .. "\n"
 
             local normalized = AIHelper:normalizeOpenRouterStream(stream, "anthropic")
             assert.is_not_nil(normalized)
             local response = json.decode(normalized)
             assert.are.equal('{"locations":[]}', response.content[1].text)
+        end)
+
+        it("joins multiple data lines in one SSE event", function()
+            local stream = table.concat({
+                "data: {\"choices\":",
+                "data: [{\"delta\":{\"content\":\"{\\\"characters\\\":[]}\"}}]}",
+                "",
+                "data: [DONE]",
+                "",
+            }, "\n") .. "\n"
+
+            local normalized = AIHelper:normalizeOpenRouterStream(stream, "openai")
+            assert.is_not_nil(normalized)
+            local response = json.decode(normalized)
+            assert.are.equal('{"characters":[]}', response.choices[1].message.content)
         end)
 
         it("surfaces mid-stream provider errors", function()
@@ -338,10 +357,63 @@ describe("AIHelper", function()
         end)
     end)
 
+    describe("async result ownership", function()
+        it("removes a pre-existing result before starting a request", function()
+            local old_ffiutil = package.loaded["ffi/util"]
+            local result_file = os.tmpname()
+            local file = io.open(result_file, "w")
+            assert.is_not_nil(file)
+            file:write("stale result")
+            file:close()
+
+            package.loaded["ffi/util"] = {
+                runInSubProcess = function()
+                    return 3333
+                end,
+            }
+
+            local pid = AIHelper:makeRequestAsync({}, result_file)
+            assert.are.equal(3333, pid)
+            assert.is_nil(io.open(result_file, "r"))
+
+            package.loaded["ffi/util"] = old_ffiutil
+            AIHelper._async_child_pid = nil
+            AIHelper._async_child_uses_process_group = nil
+            AIHelper._async_result_file = nil
+            os.remove(result_file)
+        end)
+
+        it("does not consume a newer request's result from a stale poll", function()
+            local result_file = os.tmpname()
+            local file = io.open(result_file, "w")
+            assert.is_not_nil(file)
+            file:write("new request result")
+            file:close()
+
+            AIHelper._async_child_pid = 2222
+            AIHelper._async_result_file = result_file
+
+            local result, err_code = AIHelper:checkAsyncResult(result_file, 1111)
+            assert.is_false(result)
+            assert.are.equal("error_stale", err_code)
+            assert.are.equal(2222, AIHelper._async_child_pid)
+            assert.are.equal(result_file, AIHelper._async_result_file)
+
+            local untouched = io.open(result_file, "r")
+            assert.is_not_nil(untouched)
+            assert.are.equal("new request result", untouched:read("*a"))
+            untouched:close()
+
+            AIHelper._async_child_pid = nil
+            AIHelper._async_result_file = nil
+            os.remove(result_file)
+        end)
+    end)
+
     describe("async child cancellation", function()
         it("terminates immediately and reaps only the expected child in the background", function()
             local old_ffiutil = package.loaded["ffi/util"]
-            local old_kill = AIHelper._killAsyncPID
+            local old_terminate = AIHelper._terminateAsyncProcess
             local UIManager = require("ui/uimanager")
             local old_schedule = UIManager.scheduleIn
             local calls = {}
@@ -349,15 +421,19 @@ describe("AIHelper", function()
             local reap_results = { false, false, true }
             package.loaded["ffi/util"] = {
                 terminateSubProcess = function(pid)
-                    table.insert(calls, { action = "terminate", pid = pid })
+                    error("cancelAsyncChild must not call a helper that reaps before signalling")
                 end,
                 isSubProcessDone = function(pid, wait)
                     table.insert(calls, { action = "reap", pid = pid, wait = wait })
                     return table.remove(reap_results, 1)
                 end,
             }
-            AIHelper._killAsyncPID = function(self, pid)
-                table.insert(calls, { action = "kill", pid = pid })
+            AIHelper._terminateAsyncProcess = function(self, pid, use_process_group)
+                table.insert(calls, {
+                    action = "terminate",
+                    pid = pid,
+                    use_process_group = use_process_group,
+                })
                 return true
             end
             UIManager.scheduleIn = function(self, delay, callback)
@@ -380,30 +456,30 @@ describe("AIHelper", function()
 
                 assert.is_true(AIHelper:cancelAsyncChild(4321))
                 assert.are.equal("terminate", calls[1].action)
-                assert.are.equal("kill", calls[2].action)
                 assert.are.equal(4321, calls[1].pid)
-                assert.are.equal("reap", calls[3].action)
-                assert.is_nil(calls[3].wait)
+                assert.is_true(calls[1].use_process_group)
+                assert.are.equal("reap", calls[2].action)
+                assert.is_nil(calls[2].wait)
                 assert.is_nil(AIHelper._async_child_pid)
                 assert.is_nil(AIHelper._async_result_file)
                 assert.is_nil(io.open(result_file, "r"))
                 assert.are.equal(1, #scheduled)
 
                 table.remove(scheduled, 1)()
-                assert.are.equal("reap", calls[4].action)
-                assert.is_nil(calls[4].wait)
+                assert.are.equal("reap", calls[3].action)
+                assert.is_nil(calls[3].wait)
                 assert.are.equal(1, #scheduled)
                 assert.is_true(AIHelper._async_children_to_reap[4321])
 
                 table.remove(scheduled, 1)()
-                assert.are.equal("reap", calls[5].action)
-                assert.is_nil(calls[5].wait)
+                assert.are.equal("reap", calls[4].action)
+                assert.is_nil(calls[4].wait)
                 assert.is_nil(AIHelper._async_children_to_reap)
                 assert.are.equal(0, #scheduled)
             end)
 
             package.loaded["ffi/util"] = old_ffiutil
-            AIHelper._killAsyncPID = old_kill
+            AIHelper._terminateAsyncProcess = old_terminate
             UIManager.scheduleIn = old_schedule
             AIHelper._async_child_pid = nil
             AIHelper._async_child_uses_process_group = nil

--- a/spec/xray_aihelper_spec.lua
+++ b/spec/xray_aihelper_spec.lua
@@ -335,6 +335,23 @@ describe("AIHelper", function()
             assert.are.equal('{"characters":[]}', response.choices[1].message.content)
         end)
 
+        it("accepts normal finish reasons when the DONE sentinel is missing", function()
+            for _, finish_reason in ipairs({ "stop", "length" }) do
+                local stream = "data: " .. json.encode({
+                    choices = {{
+                        delta = { content = '{"characters":[]}' },
+                        finish_reason = finish_reason,
+                    }},
+                }) .. "\n\n"
+
+                local normalized = AIHelper:normalizeOpenRouterStream(stream, "openai")
+                assert.is_not_nil(normalized)
+                local response = json.decode(normalized)
+                assert.are.equal(finish_reason, response.choices[1].finish_reason)
+                assert.are.equal('{"characters":[]}', response.choices[1].message.content)
+            end
+        end)
+
         it("surfaces mid-stream provider errors", function()
             local stream = "data: " .. json.encode({
                 error = { code = 502, message = "Provider disconnected" },
@@ -344,6 +361,24 @@ describe("AIHelper", function()
             local normalized, err = AIHelper:normalizeOpenRouterStream(stream, "openai")
             assert.is_nil(normalized)
             assert.are.equal("Provider disconnected", err)
+        end)
+
+        it("surfaces Anthropic Messages error details", function()
+            local stream = table.concat({
+                "event: error",
+                "data: " .. json.encode({
+                    type = "error",
+                    error = {
+                        type = "overloaded_error",
+                        message = "Overloaded",
+                    },
+                }),
+                "",
+            }, "\n") .. "\n"
+
+            local normalized, err = AIHelper:normalizeOpenRouterStream(stream, "anthropic")
+            assert.is_nil(normalized)
+            assert.are.equal("Overloaded", err)
         end)
 
         it("rejects incomplete streams instead of accepting partial output", function()
@@ -411,6 +446,29 @@ describe("AIHelper", function()
     end)
 
     describe("async child cancellation", function()
+        it("reuses the module-level FFI fallback when ffiutil is unavailable", function()
+            local old_ffiutil = package.loaded["ffi/util"]
+            local old_ffiutil_alias = package.loaded["ffiutil"]
+            local old_preload = package.preload["ffi/util"]
+            local old_preload_alias = package.preload["ffiutil"]
+            package.loaded["ffi/util"] = nil
+            package.loaded["ffiutil"] = nil
+            package.preload["ffi/util"] = function() error("ffiutil unavailable") end
+            package.preload["ffiutil"] = function() error("ffiutil unavailable") end
+
+            local ok, err = pcall(function()
+                for _ = 1, 3 do
+                    assert.is_true(AIHelper:_isAsyncChildDone(2147483647))
+                end
+            end)
+
+            package.loaded["ffi/util"] = old_ffiutil
+            package.loaded["ffiutil"] = old_ffiutil_alias
+            package.preload["ffi/util"] = old_preload
+            package.preload["ffiutil"] = old_preload_alias
+            if not ok then error(err) end
+        end)
+
         it("terminates immediately and reaps only the expected child in the background", function()
             local old_ffiutil = package.loaded["ffi/util"]
             local old_terminate = AIHelper._terminateAsyncProcess
@@ -486,6 +544,50 @@ describe("AIHelper", function()
             AIHelper._async_result_file = nil
             AIHelper._async_children_to_reap = nil
             pcall(function() os.remove(result_file) end)
+            if not ok then error(err) end
+        end)
+
+        it("stops reaper polling after bounded backoff", function()
+            local UIManager = require("ui/uimanager")
+            local old_schedule = UIManager.scheduleIn
+            local old_is_done = AIHelper._isAsyncChildDone
+            local old_log = AIHelper.log
+            local scheduled = {}
+            local delays = {}
+            local logs = {}
+
+            UIManager.scheduleIn = function(self, delay, callback)
+                table.insert(delays, delay)
+                table.insert(scheduled, callback)
+            end
+            AIHelper._isAsyncChildDone = function() return false end
+            AIHelper.log = function(self, message)
+                table.insert(logs, message)
+            end
+            AIHelper._async_children_to_reap = nil
+
+            local ok, err = pcall(function()
+                assert.is_true(AIHelper:_scheduleAsyncChildReap(7777))
+                local callbacks_run = 0
+                while #scheduled > 0 do
+                    callbacks_run = callbacks_run + 1
+                    table.remove(scheduled, 1)()
+                    assert.is_true(callbacks_run <= 10)
+                end
+
+                assert.are.equal(10, callbacks_run)
+                assert.are.equal(10, #delays)
+                assert.are.equal(0.1, delays[1])
+                assert.are.equal(0.2, delays[2])
+                assert.are.equal(1, delays[5])
+                assert.is_nil(AIHelper._async_children_to_reap)
+                assert.is_true(logs[#logs]:find("Timed out waiting to collect", 1, true) ~= nil)
+            end)
+
+            UIManager.scheduleIn = old_schedule
+            AIHelper._isAsyncChildDone = old_is_done
+            AIHelper.log = old_log
+            AIHelper._async_children_to_reap = nil
             if not ok then error(err) end
         end)
     end)

--- a/spec/xray_aihelper_spec.lua
+++ b/spec/xray_aihelper_spec.lua
@@ -253,6 +253,62 @@ describe("AIHelper", function()
                 assert.are.equal("HTTP 400: custom1 is not a valid model ID", err_msg)
             end)
         end)
+
+    end)
+
+    describe("async child cancellation", function()
+        it("terminates, reaps, and cleans only the expected child", function()
+            local old_ffiutil = package.loaded["ffi/util"]
+            local old_kill = AIHelper._killAsyncPID
+            local calls = {}
+            package.loaded["ffi/util"] = {
+                terminateSubProcess = function(pid)
+                    table.insert(calls, { action = "terminate", pid = pid })
+                end,
+                isSubProcessDone = function(pid, wait)
+                    table.insert(calls, { action = "reap", pid = pid, wait = wait })
+                    return true
+                end,
+            }
+            AIHelper._killAsyncPID = function(self, pid, wait)
+                table.insert(calls, { action = "kill", pid = pid, wait = wait })
+                return true
+            end
+
+            local result_file = os.tmpname()
+            local file = io.open(result_file, "w")
+            file:write("pending")
+            file:close()
+
+            AIHelper._async_child_pid = 4321
+            AIHelper._async_child_uses_process_group = true
+            AIHelper._async_result_file = result_file
+
+            local ok, err = pcall(function()
+                assert.is_false(AIHelper:cancelAsyncChild(9999))
+                assert.are.equal(4321, AIHelper._async_child_pid)
+                assert.are.equal(0, #calls)
+
+                assert.is_true(AIHelper:cancelAsyncChild(4321))
+                assert.are.equal("kill", calls[1].action)
+                assert.are.equal(4321, calls[1].pid)
+                assert.is_false(calls[1].wait)
+                assert.are.equal("terminate", calls[2].action)
+                assert.are.equal("reap", calls[3].action)
+                assert.is_true(calls[3].wait)
+                assert.is_nil(AIHelper._async_child_pid)
+                assert.is_nil(AIHelper._async_result_file)
+                assert.is_nil(io.open(result_file, "r"))
+            end)
+
+            package.loaded["ffi/util"] = old_ffiutil
+            AIHelper._killAsyncPID = old_kill
+            AIHelper._async_child_pid = nil
+            AIHelper._async_child_uses_process_group = nil
+            AIHelper._async_result_file = nil
+            pcall(function() os.remove(result_file) end)
+            if not ok then error(err) end
+        end)
     end)
 
     describe("isAnthropic", function()

--- a/spec/xray_fetch_spec.lua
+++ b/spec/xray_fetch_spec.lua
@@ -18,6 +18,96 @@ describe("xray_fetch", function()
         }
     end)
 
+    describe("continueWithFetch cancellation", function()
+        it("cancels the owned child and allows a new fetch before the old poll runs", function()
+            local UIManager = require("ui/uimanager")
+            local old_schedule = UIManager.scheduleIn
+            local old_remove = os.remove
+            local scheduled = {}
+            local removed_files = {}
+            local started_pids = { 501, 502 }
+            local start_count = 0
+            local cancelled_pids = {}
+
+            UIManager.scheduleIn = function(self, delay, callback)
+                table.insert(scheduled, callback)
+            end
+            os.remove = function(path)
+                table.insert(removed_files, path)
+                return true
+            end
+
+            plugin.ui.getCurrentPage = function() return 10 end
+            plugin.chapter_analyzer = {
+                getTextForAnalysis = function() return "enough extracted book text" end,
+                getDetailedChapterSamples = function() return "chapter samples", { "Chapter 1" } end,
+                getAnnotationsForAnalysis = function() return nil end,
+            }
+            plugin.ai_helper = {
+                settings = { spoiler_setting = "spoiler_free" },
+                buildComprehensiveRequest = function()
+                    return { { url = "https://example.invalid" } }
+                end,
+                makeRequestAsync = function(self)
+                    start_count = start_count + 1
+                    self._async_child_pid = started_pids[start_count]
+                    return self._async_child_pid
+                end,
+                cancelAsyncChild = function(self, expected_pid)
+                    table.insert(cancelled_pids, expected_pid)
+                    if self._async_child_pid ~= expected_pid then return false end
+                    self._async_child_pid = nil
+                    return true
+                end,
+                checkAsyncResult = function() return nil end,
+            }
+
+            local function runNext()
+                local callback = table.remove(scheduled, 1)
+                assert.is_not_nil(callback)
+                callback()
+            end
+
+            local ok, err = pcall(function()
+                plugin:continueWithFetch(50)
+                local first_dialog = _G.ui_tracker.last_shown
+                runNext() -- deferred extraction
+                runNext() -- request construction and start
+
+                assert.are.equal(501, plugin.ai_helper._async_child_pid)
+                assert.is_true(plugin.bg_fetch_active)
+
+                first_dialog.args.buttons[1][1].callback()
+                assert.are.equal(501, cancelled_pids[1])
+                assert.is_false(plugin.bg_fetch_active)
+                assert.is_true(#removed_files > 0)
+
+                -- Start again before the cancelled fetch's queued poll runs.
+                plugin:continueWithFetch(50)
+                local second_dialog = _G.ui_tracker.last_shown
+                assert.is_true(plugin.bg_fetch_active)
+
+                runNext() -- stale poll from the cancelled fetch
+                assert.is_true(plugin.bg_fetch_active)
+                assert.are.equal(1, #cancelled_pids)
+
+                runNext() -- second fetch extraction
+                runNext() -- second request start
+                assert.are.equal(2, start_count)
+                assert.are.equal(502, plugin.ai_helper._async_child_pid)
+                assert.is_true(plugin.bg_fetch_active)
+
+                second_dialog.args.buttons[1][1].callback()
+                assert.are.equal(502, cancelled_pids[2])
+                assert.is_false(plugin.bg_fetch_active)
+            end)
+
+            UIManager.scheduleIn = old_schedule
+            os.remove = old_remove
+            if not ok then error(err) end
+        end)
+    end)
+
     describe("finalizeXRayData", function()
         it("merges new characters correctly in update mode", function()
             plugin.characters = {
@@ -200,5 +290,4 @@ describe("xray_fetch", function()
         end)
     end)
 end)
-
 

--- a/xray.koplugin/main.lua
+++ b/xray.koplugin/main.lua
@@ -2201,6 +2201,16 @@ function XRayPlugin:triggerBookTypeDetection()
     end
     local cached = self.book_data
 
+    local function newBookTypeResultFile()
+        local DataStorage = require("datastorage")
+        return string.format(
+            "%s/xray/book_type_detect_res_%d_%d.json",
+            DataStorage:getDataDir(),
+            os.time(),
+            math.random(1000, 9999)
+        )
+    end
+
     -- Check if we already have a unit cache first to avoid scans
     local has_unit_cache = false
     if self.loadUnitCache then
@@ -2236,8 +2246,7 @@ function XRayPlugin:triggerBookTypeDetection()
         -- If the cached label was not detected by AI, check if we should refine it via AI background process
         if not cached.book_type_detected_by_ai and self.ai_helper:hasApiKey() then
             -- Trigger AI in background to refine low-confidence or format-fallback guesses
-            local DataStorage = require("datastorage")
-            local result_file = DataStorage:getDataDir() .. "/xray/book_type_detect_res.json"
+            local result_file = newBookTypeResultFile()
             local props = self.ui.document:getProps() or {}
             local title = props.title or "Unknown"
             local author = props.authors or "Unknown"
@@ -2247,8 +2256,8 @@ function XRayPlugin:triggerBookTypeDetection()
             if pid then
                 local function pollResult()
                     if self.destroyed then return end
-                    local res = self.ai_helper:checkAsyncResult(result_file)
-                    if res == "pending" then
+                    local res = self.ai_helper:checkAsyncResult(result_file, pid)
+                    if res == nil then
                         UIManager:scheduleIn(1, pollResult)
                     elseif type(res) == "table" and res.book_type_label then
                         cached.book_type_label = res.book_type_label
@@ -2282,8 +2291,7 @@ function XRayPlugin:triggerBookTypeDetection()
                 return true
             end
             self:log("XRayPlugin: Starting Layer 3 AI book type refinement in background...")
-            local DataStorage = require("datastorage")
-            local result_file = DataStorage:getDataDir() .. "/xray/book_type_detect_res.json"
+            local result_file = newBookTypeResultFile()
             local props = self.ui.document:getProps() or {}
             local title = props.title or "Unknown"
             local author = props.authors or "Unknown"
@@ -2293,8 +2301,8 @@ function XRayPlugin:triggerBookTypeDetection()
             if pid then
                 local function pollResult()
                     if self.destroyed then return end
-                    local res = self.ai_helper:checkAsyncResult(result_file)
-                    if res == "pending" then
+                    local res = self.ai_helper:checkAsyncResult(result_file, pid)
+                    if res == nil then
                         UIManager:scheduleIn(1, pollResult)
                     elseif type(res) == "table" and res.book_type_label then
                         self:log("XRayPlugin: Book type AI refinement complete! Result: " .. tostring(res.book_type_label))
@@ -2316,8 +2324,7 @@ function XRayPlugin:triggerBookTypeDetection()
     end
 
     self:log("XRayPlugin: Starting Layer 3 AI book type detection in background...")
-    local DataStorage = require("datastorage")
-    local result_file = DataStorage:getDataDir() .. "/xray/book_type_detect_res.json"
+    local result_file = newBookTypeResultFile()
     
     local props = self.ui.document:getProps() or {}
     local title = props.title or "Unknown"
@@ -2334,8 +2341,8 @@ function XRayPlugin:triggerBookTypeDetection()
 
     local function pollResult()
         if self.destroyed then return end
-        local res = self.ai_helper:checkAsyncResult(result_file)
-        if res == "pending" then
+        local res = self.ai_helper:checkAsyncResult(result_file, pid)
+        if res == nil then
             UIManager:scheduleIn(1, pollResult)
         elseif type(res) == "table" and res.book_type_label then
             self:log("XRayPlugin: Book type AI detection complete! Result: " .. tostring(res.book_type_label))

--- a/xray.koplugin/xray_aihelper.lua
+++ b/xray.koplugin/xray_aihelper.lua
@@ -506,13 +506,18 @@ function AIHelper:_reapAsyncChild(pid)
     return false
 end
 
-function AIHelper:_killAsyncPID(pid)
-    local ok, result = pcall(function()
+function AIHelper:_terminateAsyncProcess(pid, use_process_group)
+    local ok, termination_requested = pcall(function()
         local ffi = require("ffi")
         ffi.cdef[[ int kill(int pid, int sig); ]]
-        return ffi.C.kill(pid, 9) -- SIGKILL
+        local group_killed = false
+        if use_process_group then
+            group_killed = ffi.C.kill(-pid, 9) == 0 -- SIGKILL
+        end
+        local child_killed = ffi.C.kill(pid, 9) == 0
+        return group_killed or child_killed
     end)
-    return ok and result == 0
+    return ok and termination_requested == true
 end
 
 function AIHelper:_scheduleAsyncChildReap(pid)
@@ -550,46 +555,53 @@ function AIHelper:normalizeOpenRouterStream(response_text, stream_format)
     local content = {}
     local stream_complete = false
 
-    for line in ((response_text or "") .. "\n"):gmatch("(.-)\n") do
-        line = line:gsub("\r$", "")
-        if line:sub(1, 5) == "data:" then
-            local payload = line:sub(6):match("^%s*(.-)%s*$")
-            if payload == "[DONE]" then
-                stream_complete = true
-            elseif payload ~= "" then
-                local ok, event = pcall(json.decode, payload)
-                if not ok or type(event) ~= "table" then
-                    return nil, "OpenRouter returned malformed stream data"
-                end
-                if event.error then
-                    local message = type(event.error) == "table" and event.error.message or event.error
-                    return nil, tostring(message or "OpenRouter stream failed")
-                end
+    local normalized_stream = (response_text or ""):gsub("\r\n", "\n"):gsub("\r", "\n")
+    for event_block in (normalized_stream .. "\n\n"):gmatch("(.-)\n\n") do
+        local data_lines = {}
+        for line in (event_block .. "\n"):gmatch("(.-)\n") do
+            local data = line:match("^data:(.*)$")
+            if data then
+                local value = data:gsub("^ ", "")
+                table.insert(data_lines, value)
+            end
+        end
 
-                if stream_format == "openai" then
-                    local choice = event.choices and event.choices[1]
-                    local delta = choice and choice.delta
-                    if delta and type(delta.content) == "string" then
-                        table.insert(content, delta.content)
-                    end
-                    if choice and choice.finish_reason == "error" then
-                        return nil, "OpenRouter stream failed"
-                    end
-                else
-                    if event.type == "content_block_start"
-                        and event.content_block
-                        and type(event.content_block.text) == "string" then
-                        table.insert(content, event.content_block.text)
-                    elseif event.type == "content_block_delta"
-                        and event.delta
-                        and event.delta.type == "text_delta"
-                        and type(event.delta.text) == "string" then
-                        table.insert(content, event.delta.text)
-                    elseif event.type == "message_stop" then
-                        stream_complete = true
-                    elseif event.type == "error" then
-                        return nil, "OpenRouter stream failed"
-                    end
+        local payload = table.concat(data_lines, "\n")
+        if payload == "[DONE]" then
+            stream_complete = true
+        elseif payload ~= "" then
+            local ok, event = pcall(json.decode, payload)
+            if not ok or type(event) ~= "table" then
+                return nil, "OpenRouter returned malformed stream data"
+            end
+            if event.error then
+                local message = type(event.error) == "table" and event.error.message or event.error
+                return nil, tostring(message or "OpenRouter stream failed")
+            end
+
+            if stream_format == "openai" then
+                local choice = event.choices and event.choices[1]
+                local delta = choice and choice.delta
+                if delta and type(delta.content) == "string" then
+                    table.insert(content, delta.content)
+                end
+                if choice and choice.finish_reason == "error" then
+                    return nil, "OpenRouter stream failed"
+                end
+            else
+                if event.type == "content_block_start"
+                    and event.content_block
+                    and type(event.content_block.text) == "string" then
+                    table.insert(content, event.content_block.text)
+                elseif event.type == "content_block_delta"
+                    and event.delta
+                    and event.delta.type == "text_delta"
+                    and type(event.delta.text) == "string" then
+                    table.insert(content, event.delta.text)
+                elseif event.type == "message_stop" then
+                    stream_complete = true
+                elseif event.type == "error" then
+                    return nil, "OpenRouter stream failed"
                 end
             end
         end
@@ -622,6 +634,10 @@ function AIHelper:makeRequestAsync(request_params, result_file)
     if self._async_child_pid and not self:_reapAsyncChild(self._async_child_pid) then
         self:log("AIHelper: Cannot start async request while PID " .. tostring(self._async_child_pid) .. " is still active")
         return false
+    end
+
+    if result_file then
+        pcall(function() os.remove(result_file) end)
     end
 
     local ffiutil = getFFIUtil()
@@ -960,6 +976,15 @@ end
 --   book_data table (success)
 --   false, error_code, error_msg (failed)
 function AIHelper:checkAsyncResult(result_file, expected_pid)
+    if expected_pid then
+        local owns_expected_request = self._async_child_pid == expected_pid
+            and self._async_result_file == result_file
+        if not owns_expected_request then
+            self:log("AIHelper: Ignoring stale async result poll for PID " .. tostring(expected_pid))
+            return false, "error_stale", "Async result belongs to a different request"
+        end
+    end
+
     local f = io.open(result_file, "r")
     if not f then return nil end  -- still pending
 
@@ -1063,19 +1088,13 @@ function AIHelper:cancelAsyncChild(expected_pid)
 
     self:log("AIHelper: Cancelling async child process PID " .. tostring(pid))
     local result_file = self._async_result_file
-    local termination_requested = false
-    local ffiutil = getFFIUtil()
-
-    if self._async_child_uses_process_group and ffiutil
-        and ffiutil.terminateSubProcess then
-        local ok = pcall(function()
-            ffiutil.terminateSubProcess(pid)
-        end)
-        termination_requested = ok
-    end
-    -- runInSubProcess creates the process group inside the child. Also signal
-    -- the PID directly in case cancellation happens before setpgid().
-    termination_requested = self:_killAsyncPID(pid) or termination_requested
+    -- Signal the process group without first calling a helper that may reap
+    -- the child. Also signal the PID in case cancellation happens before the
+    -- child creates its process group.
+    local termination_requested = self:_terminateAsyncProcess(
+        pid,
+        self._async_child_uses_process_group
+    )
 
     if not termination_requested and not self:_reapAsyncChild(pid) then
         self:log("AIHelper: Failed to terminate async child PID " .. tostring(pid))

--- a/xray.koplugin/xray_aihelper.lua
+++ b/xray.koplugin/xray_aihelper.lua
@@ -5,6 +5,29 @@ local ok_ltn12, ltn12 = pcall(require, "ltn12")
 local ok_socket, socket = pcall(require, "socket")
 local ok_socketutil, socketutil = pcall(require, "socketutil")
 
+local process_ffi
+do
+    local ok_ffi, ffi = pcall(require, "ffi")
+    if ok_ffi then
+        pcall(function()
+            ffi.cdef[[
+                int close(int fd);
+                int fork(void);
+                int kill(int pid, int sig);
+                int waitpid(int pid, int *status, int options);
+                void _exit(int status);
+            ]]
+        end)
+        process_ffi = ffi
+    end
+end
+
+local SIGKILL = 9
+local WNOHANG = 1
+local REAP_INITIAL_DELAY = 0.1
+local REAP_MAX_DELAY = 1
+local REAP_MAX_ATTEMPTS = 10
+
 local logger = require("logger")
 local plugin_path = ((...) or ""):match("(.-)[^%.]+$") or ""
 local XRayLogger = require(plugin_path .. "xray_logger")
@@ -485,10 +508,9 @@ function AIHelper:_isAsyncChildDone(pid)
         if ok then return done == true end
     end
 
+    if not process_ffi then return false end
     local ok, done = pcall(function()
-        local ffi = require("ffi")
-        ffi.cdef[[ int waitpid(int pid, int *status, int options); ]]
-        local result = ffi.C.waitpid(pid, nil, 1) -- WNOHANG
+        local result = process_ffi.C.waitpid(pid, nil, WNOHANG)
         return result == pid or result == -1
     end)
     return ok and done == true
@@ -507,14 +529,13 @@ function AIHelper:_reapAsyncChild(pid)
 end
 
 function AIHelper:_terminateAsyncProcess(pid, use_process_group)
+    if not process_ffi then return false end
     local ok, termination_requested = pcall(function()
-        local ffi = require("ffi")
-        ffi.cdef[[ int kill(int pid, int sig); ]]
         local group_killed = false
         if use_process_group then
-            group_killed = ffi.C.kill(-pid, 9) == 0 -- SIGKILL
+            group_killed = process_ffi.C.kill(-pid, SIGKILL) == 0
         end
-        local child_killed = ffi.C.kill(pid, 9) == 0
+        local child_killed = process_ffi.C.kill(pid, SIGKILL) == 0
         return group_killed or child_killed
     end)
     return ok and termination_requested == true
@@ -531,19 +552,32 @@ function AIHelper:_scheduleAsyncChildReap(pid)
         return false
     end
 
-    local collect
-    collect = function()
-        if self:_isAsyncChildDone(pid) then
-            self._async_children_to_reap[pid] = nil
-            if not next(self._async_children_to_reap) then
-                self._async_children_to_reap = nil
-            end
-            self:log("AIHelper: Collected async child process PID " .. tostring(pid))
-        else
-            UIManager:scheduleIn(0.1, collect)
+    local attempts = 0
+    local delay = REAP_INITIAL_DELAY
+    local function stopTracking()
+        local pending = self._async_children_to_reap
+        if not pending then return end
+        pending[pid] = nil
+        if not next(pending) then
+            self._async_children_to_reap = nil
         end
     end
-    UIManager:scheduleIn(0.1, collect)
+
+    local collect
+    collect = function()
+        attempts = attempts + 1
+        if self:_isAsyncChildDone(pid) then
+            stopTracking()
+            self:log("AIHelper: Collected async child process PID " .. tostring(pid))
+        elseif attempts >= REAP_MAX_ATTEMPTS then
+            stopTracking()
+            self:log("AIHelper: Timed out waiting to collect async child PID " .. tostring(pid))
+        else
+            delay = math.min(delay * 2, REAP_MAX_DELAY)
+            UIManager:scheduleIn(delay, collect)
+        end
+    end
+    UIManager:scheduleIn(delay, collect)
     return true
 end
 
@@ -554,6 +588,7 @@ function AIHelper:normalizeOpenRouterStream(response_text, stream_format)
 
     local content = {}
     local stream_complete = false
+    local finish_reason = "stop"
 
     local normalized_stream = (response_text or ""):gsub("\r\n", "\n"):gsub("\r", "\n")
     for event_block in (normalized_stream .. "\n\n"):gmatch("(.-)\n\n") do
@@ -585,8 +620,13 @@ function AIHelper:normalizeOpenRouterStream(response_text, stream_format)
                 if delta and type(delta.content) == "string" then
                     table.insert(content, delta.content)
                 end
-                if choice and choice.finish_reason == "error" then
-                    return nil, "OpenRouter stream failed"
+                if choice then
+                    if choice.finish_reason == "error" then
+                        return nil, "OpenRouter stream failed"
+                    elseif choice.finish_reason == "stop" or choice.finish_reason == "length" then
+                        finish_reason = choice.finish_reason
+                        stream_complete = true
+                    end
                 end
             else
                 if event.type == "content_block_start"
@@ -623,7 +663,7 @@ function AIHelper:normalizeOpenRouterStream(response_text, stream_format)
     end
     return json.encode({
         choices = {{
-            finish_reason = "stop",
+            finish_reason = finish_reason,
             message = { role = "assistant", content = text },
         }},
     })
@@ -888,20 +928,16 @@ function AIHelper:makeRequestAsync(request_params, result_file)
         end
 
         -- Close write_fd if provided by runInSubProcess
-        if write_fd and write_fd > 0 then
-            pcall(function() 
-                local ffi = require("ffi")
-                ffi.cdef[[ int close(int fd); ]]
-                ffi.C.close(write_fd) 
+        if process_ffi and write_fd and write_fd > 0 then
+            pcall(function()
+                process_ffi.C.close(write_fd)
             end)
         end
 
         -- Exit child cleanly
-        local ffi_ok, ffi = pcall(require, "ffi")
-        if ffi_ok then
+        if process_ffi then
             pcall(function()
-                ffi.cdef[[ void _exit(int status); ]]
-                ffi.C._exit(0)
+                process_ffi.C._exit(0)
             end)
         end
         local posix_ok, posix = pcall(require, "posix.unistd")
@@ -919,11 +955,9 @@ function AIHelper:makeRequestAsync(request_params, result_file)
         if pid and pid > 0 then
             self:log("AIHelper: runInSubProcess started PID " .. tostring(pid))
             -- We don't need the pipe for now as we use the result_file
-            if read_fd and read_fd > 0 then
-                pcall(function() 
-                    local ffi = require("ffi")
-                    ffi.cdef[[ int close(int fd); ]]
-                    ffi.C.close(read_fd) 
+            if process_ffi and read_fd and read_fd > 0 then
+                pcall(function()
+                    process_ffi.C.close(read_fd)
                 end)
             end
             self._async_child_pid = pid
@@ -942,14 +976,10 @@ function AIHelper:makeRequestAsync(request_params, result_file)
         if not ok_posix then ok_posix, posix = pcall(require, "posix") end
         if ok_posix and posix and posix.fork then
             fork = posix.fork
-        else
-            local ok_f, ffi = pcall(require, "ffi")
-            if ok_f then
-                pcall(function()
-                    ffi.cdef[[ int fork(void); ]]
-                    fork = ffi.C.fork
-                end)
-            end
+        elseif process_ffi then
+            pcall(function()
+                fork = process_ffi.C.fork
+            end)
         end
     end
     

--- a/xray.koplugin/xray_aihelper.lua
+++ b/xray.koplugin/xray_aihelper.lua
@@ -447,12 +447,75 @@ function AIHelper:hasApiKey()
     return false
 end
 
+local function getFFIUtil()
+    local ok, ffiutil = pcall(require, "ffi/util")
+    if not ok then
+        ok, ffiutil = pcall(require, "ffiutil")
+    end
+    return ok and ffiutil or nil
+end
+
+function AIHelper:_clearAsyncChildState(pid)
+    if self._async_child_pid == pid then
+        self._async_child_pid = nil
+        self._async_child_uses_process_group = nil
+        self._async_result_file = nil
+    end
+end
+
+-- Reap a completed child without touching a newer request that may have
+-- replaced it. When wait is true, this blocks until the child exits.
+function AIHelper:_reapAsyncChild(pid, wait)
+    if not pid or self._async_child_pid ~= pid then return false end
+
+    local ffiutil = getFFIUtil()
+    if ffiutil and ffiutil.isSubProcessDone then
+        local ok, done = pcall(ffiutil.isSubProcessDone, pid, wait == true)
+        if ok and done then
+            self:_clearAsyncChildState(pid)
+            return true
+        end
+    end
+
+    local ok, done = pcall(function()
+        local ffi = require("ffi")
+        ffi.cdef[[ int waitpid(int pid, int *status, int options); ]]
+        local result = ffi.C.waitpid(pid, nil, wait and 0 or 1)
+        return result == pid or result == -1
+    end)
+    if ok and done then
+        self:_clearAsyncChildState(pid)
+        return true
+    end
+    return false
+end
+
+function AIHelper:_killAsyncPID(pid, wait)
+    local ok, done = pcall(function()
+        local ffi = require("ffi")
+        ffi.cdef[[
+            int kill(int pid, int sig);
+            int waitpid(int pid, int *status, int options);
+        ]]
+        local kill_result = ffi.C.kill(pid, 9) -- SIGKILL
+        if not wait then
+            return kill_result == 0 or kill_result == -1
+        end
+        local wait_result = ffi.C.waitpid(pid, nil, 0)
+        return kill_result == 0 or wait_result == pid or wait_result == -1
+    end)
+    return ok and done == true
+end
+
 -- Fork a child process to perform the HTTP request. Returns true if started.
 function AIHelper:makeRequestAsync(request_params, result_file)
-    local ok_ffi, ffiutil = pcall(require, "ffi/util")
-    if not ok_ffi then
-        ok_ffi, ffiutil = pcall(require, "ffiutil")
+    if self._async_child_pid and not self:_reapAsyncChild(self._async_child_pid, false) then
+        self:log("AIHelper: Cannot start async request while PID " .. tostring(self._async_child_pid) .. " is still active")
+        return false
     end
+
+    local ffiutil = getFFIUtil()
+    local ok_ffi = ffiutil ~= nil
     
     local function child_logic(pid, write_fd)
         local child_ok, child_err = pcall(function()
@@ -725,6 +788,8 @@ function AIHelper:makeRequestAsync(request_params, result_file)
                 end)
             end
             self._async_child_pid = pid
+            self._async_child_uses_process_group = true
+            self._async_result_file = result_file
             return pid
         end
     end
@@ -757,6 +822,8 @@ function AIHelper:makeRequestAsync(request_params, result_file)
         elseif pid and pid > 0 then
             self:log("AIHelper: Manual fork started PID " .. tostring(pid))
             self._async_child_pid = pid
+            self._async_child_uses_process_group = false
+            self._async_result_file = result_file
             return pid
         end
     end
@@ -769,7 +836,7 @@ end
 --   nil (still pending)
 --   book_data table (success)
 --   false, error_code, error_msg (failed)
-function AIHelper:checkAsyncResult(result_file)
+function AIHelper:checkAsyncResult(result_file, expected_pid)
     local f = io.open(result_file, "r")
     if not f then return nil end  -- still pending
 
@@ -777,13 +844,12 @@ function AIHelper:checkAsyncResult(result_file)
     f:close()
     os.remove(result_file)
 
-    -- Reap child process to prevent zombies
-    if self._async_child_pid then
-        pcall(function()
-            local posix_sys = require("posix.sys.wait")
-            posix_sys.wait(self._async_child_pid, posix_sys.WNOHANG)
-        end)
-        self._async_child_pid = nil
+    -- Reap only the child that owns this result. A stale poll from an older
+    -- request must never clear the PID of a newer request.
+    local tracked_pid = self._async_child_pid
+    local owns_result = not self._async_result_file or self._async_result_file == result_file
+    if tracked_pid and owns_result and (not expected_pid or expected_pid == tracked_pid) then
+        self:_reapAsyncChild(tracked_pid, true)
     end
 
     -- Parse: first line = code, second line = provider, rest = response body
@@ -859,24 +925,45 @@ function AIHelper:checkAsyncResult(result_file)
     end
 end
 
-function AIHelper:cancelAsyncChild()
-    if self._async_child_pid then
-        self:log("AIHelper: Cancelling async child process PID " .. tostring(self._async_child_pid))
-        pcall(function()
-            local ffi = require("ffi")
-            ffi.cdef[[
-                int kill(int pid, int sig);
-                int waitpid(int pid, int *status, int options);
-            ]]
-            ffi.C.kill(self._async_child_pid, 9) -- SIGKILL
-            ffi.C.waitpid(self._async_child_pid, nil, 1) -- WNOHANG = 1
-        end)
-        pcall(function()
-            local posix_sys = require("posix.sys.wait")
-            posix_sys.wait(self._async_child_pid, posix_sys.WNOHANG)
-        end)
-        self._async_child_pid = nil
+function AIHelper:cancelAsyncChild(expected_pid)
+    local pid = self._async_child_pid
+    if not pid then return false end
+    if expected_pid and expected_pid ~= pid then
+        self:log("AIHelper: Refusing to cancel stale PID " .. tostring(expected_pid) .. "; active PID is " .. tostring(pid))
+        return false
     end
+
+    self:log("AIHelper: Cancelling async child process PID " .. tostring(pid))
+    local result_file = self._async_result_file
+    local cancelled = false
+    local ffiutil = getFFIUtil()
+
+    if self._async_child_uses_process_group and ffiutil
+        and ffiutil.terminateSubProcess and ffiutil.isSubProcessDone then
+        local ok, done = pcall(function()
+            -- runInSubProcess creates the process group inside the child.
+            -- Also signal the PID directly in case cancellation wins that race.
+            self:_killAsyncPID(pid, false)
+            ffiutil.terminateSubProcess(pid)
+            return ffiutil.isSubProcessDone(pid, true)
+        end)
+        cancelled = ok and done == true
+    end
+
+    if not cancelled then
+        cancelled = self:_killAsyncPID(pid, true)
+    end
+
+    if not cancelled then
+        self:log("AIHelper: Failed to terminate async child PID " .. tostring(pid))
+        return false
+    end
+
+    self:_clearAsyncChildState(pid)
+    if result_file then
+        pcall(function() os.remove(result_file) end)
+    end
+    return true
 end
 
 function AIHelper:init(path)

--- a/xray.koplugin/xray_aihelper.lua
+++ b/xray.koplugin/xray_aihelper.lua
@@ -463,53 +463,73 @@ function AIHelper:_clearAsyncChildState(pid)
     end
 end
 
--- Reap a completed child without touching a newer request that may have
--- replaced it. When wait is true, this blocks until the child exits.
-function AIHelper:_reapAsyncChild(pid, wait)
-    if not pid or self._async_child_pid ~= pid then return false end
-
+function AIHelper:_isAsyncChildDone(pid)
     local ffiutil = getFFIUtil()
     if ffiutil and ffiutil.isSubProcessDone then
-        local ok, done = pcall(ffiutil.isSubProcessDone, pid, wait == true)
-        if ok and done then
-            self:_clearAsyncChildState(pid)
-            return true
-        end
+        local ok, done = pcall(ffiutil.isSubProcessDone, pid)
+        if ok then return done == true end
     end
 
     local ok, done = pcall(function()
         local ffi = require("ffi")
         ffi.cdef[[ int waitpid(int pid, int *status, int options); ]]
-        local result = ffi.C.waitpid(pid, nil, wait and 0 or 1)
+        local result = ffi.C.waitpid(pid, nil, 1) -- WNOHANG
         return result == pid or result == -1
     end)
-    if ok and done then
+    return ok and done == true
+end
+
+-- Reap a completed child without touching a newer request that may have
+-- replaced it.
+function AIHelper:_reapAsyncChild(pid)
+    if not pid or self._async_child_pid ~= pid then return false end
+
+    if self:_isAsyncChildDone(pid) then
         self:_clearAsyncChildState(pid)
         return true
     end
     return false
 end
 
-function AIHelper:_killAsyncPID(pid, wait)
-    local ok, done = pcall(function()
+function AIHelper:_killAsyncPID(pid)
+    local ok, result = pcall(function()
         local ffi = require("ffi")
-        ffi.cdef[[
-            int kill(int pid, int sig);
-            int waitpid(int pid, int *status, int options);
-        ]]
-        local kill_result = ffi.C.kill(pid, 9) -- SIGKILL
-        if not wait then
-            return kill_result == 0 or kill_result == -1
-        end
-        local wait_result = ffi.C.waitpid(pid, nil, 0)
-        return kill_result == 0 or wait_result == pid or wait_result == -1
+        ffi.cdef[[ int kill(int pid, int sig); ]]
+        return ffi.C.kill(pid, 9) -- SIGKILL
     end)
-    return ok and done == true
+    return ok and result == 0
+end
+
+function AIHelper:_scheduleAsyncChildReap(pid)
+    self._async_children_to_reap = self._async_children_to_reap or {}
+    if self._async_children_to_reap[pid] then return true end
+    self._async_children_to_reap[pid] = true
+
+    local ok, UIManager = pcall(require, "ui/uimanager")
+    if not ok or not UIManager or not UIManager.scheduleIn then
+        self._async_children_to_reap[pid] = nil
+        return false
+    end
+
+    local collect
+    collect = function()
+        if self:_isAsyncChildDone(pid) then
+            self._async_children_to_reap[pid] = nil
+            if not next(self._async_children_to_reap) then
+                self._async_children_to_reap = nil
+            end
+            self:log("AIHelper: Collected async child process PID " .. tostring(pid))
+        else
+            UIManager:scheduleIn(0.1, collect)
+        end
+    end
+    UIManager:scheduleIn(0.1, collect)
+    return true
 end
 
 -- Fork a child process to perform the HTTP request. Returns true if started.
 function AIHelper:makeRequestAsync(request_params, result_file)
-    if self._async_child_pid and not self:_reapAsyncChild(self._async_child_pid, false) then
+    if self._async_child_pid and not self:_reapAsyncChild(self._async_child_pid) then
         self:log("AIHelper: Cannot start async request while PID " .. tostring(self._async_child_pid) .. " is still active")
         return false
     end
@@ -849,7 +869,12 @@ function AIHelper:checkAsyncResult(result_file, expected_pid)
     local tracked_pid = self._async_child_pid
     local owns_result = not self._async_result_file or self._async_result_file == result_file
     if tracked_pid and owns_result and (not expected_pid or expected_pid == tracked_pid) then
-        self:_reapAsyncChild(tracked_pid, true)
+        if not self:_reapAsyncChild(tracked_pid) then
+            self:_clearAsyncChildState(tracked_pid)
+            if not self:_scheduleAsyncChildReap(tracked_pid) then
+                self:log("AIHelper: Could not schedule collection of completed child PID " .. tostring(tracked_pid))
+            end
+        end
     end
 
     -- Parse: first line = code, second line = provider, rest = response body
@@ -935,26 +960,21 @@ function AIHelper:cancelAsyncChild(expected_pid)
 
     self:log("AIHelper: Cancelling async child process PID " .. tostring(pid))
     local result_file = self._async_result_file
-    local cancelled = false
+    local termination_requested = false
     local ffiutil = getFFIUtil()
 
     if self._async_child_uses_process_group and ffiutil
-        and ffiutil.terminateSubProcess and ffiutil.isSubProcessDone then
-        local ok, done = pcall(function()
-            -- runInSubProcess creates the process group inside the child.
-            -- Also signal the PID directly in case cancellation wins that race.
-            self:_killAsyncPID(pid, false)
+        and ffiutil.terminateSubProcess then
+        local ok = pcall(function()
             ffiutil.terminateSubProcess(pid)
-            return ffiutil.isSubProcessDone(pid, true)
         end)
-        cancelled = ok and done == true
+        termination_requested = ok
     end
+    -- runInSubProcess creates the process group inside the child. Also signal
+    -- the PID directly in case cancellation happens before setpgid().
+    termination_requested = self:_killAsyncPID(pid) or termination_requested
 
-    if not cancelled then
-        cancelled = self:_killAsyncPID(pid, true)
-    end
-
-    if not cancelled then
+    if not termination_requested and not self:_reapAsyncChild(pid) then
         self:log("AIHelper: Failed to terminate async child PID " .. tostring(pid))
         return false
     end
@@ -962,6 +982,9 @@ function AIHelper:cancelAsyncChild(expected_pid)
     self:_clearAsyncChildState(pid)
     if result_file then
         pcall(function() os.remove(result_file) end)
+    end
+    if not self:_isAsyncChildDone(pid) and not self:_scheduleAsyncChildReap(pid) then
+        self:log("AIHelper: Could not schedule collection of cancelled child PID " .. tostring(pid))
     end
     return true
 end

--- a/xray.koplugin/xray_aihelper.lua
+++ b/xray.koplugin/xray_aihelper.lua
@@ -238,7 +238,7 @@ function AIHelper:buildComprehensiveRequest(title, author, context, prompt_overr
     for _, ai in ipairs({ primary, secondary }) do
         local config = self.providers[ai.provider]
         if config and config.api_key and config.api_key ~= "" then
-            local url, headers, body
+            local url, headers, body, stream_format
             local resolved_model = self:resolveModel(ai.provider, ai.model)
             if ai.provider == "gemini" then
                 local model = resolved_model or DEFAULT_AI.primary.model
@@ -306,11 +306,11 @@ function AIHelper:buildComprehensiveRequest(title, author, context, prompt_overr
                     headers["Authorization"] = "Bearer " .. config.api_key
                 end
                 
-                if ai.provider == "custom1" or ai.provider == "custom2" then
-                    if (config.endpoint or ""):find("openrouter.ai") then
-                        headers["HTTP-Referer"]      = "https://github.com/koreader/koreader-xray-plugin"
-                        headers["X-Title"] = "KOReader X-Ray"
-                    end
+                local is_openrouter = (ai.provider == "custom1" or ai.provider == "custom2")
+                    and (config.endpoint or ""):find("openrouter.ai", 1, true)
+                if is_openrouter then
+                    headers["HTTP-Referer"] = "https://github.com/koreader/koreader-xray-plugin"
+                    headers["X-Title"] = "KOReader X-Ray"
                 end
                 
                 local system_instruction_text = (self.prompts and self.prompts.system_instruction or "Return valid JSON ONLY.") .. " You MUST output strictly valid JSON, starting with '{'."
@@ -351,6 +351,11 @@ function AIHelper:buildComprehensiveRequest(title, author, context, prompt_overr
                 local is_reasoning = self.settings and self.settings[ai.provider .. "_is_reasoning"]
                 if is_reasoning then
                     req_body.max_tokens = 32000
+                end
+                if is_openrouter then
+                    req_body.stream = true
+                    headers["Accept"] = "text/event-stream"
+                    stream_format = "anthropic"
                 end
                 
                 body = json.encode(req_body)
@@ -412,9 +417,12 @@ function AIHelper:buildComprehensiveRequest(title, author, context, prompt_overr
                 end
                 
                 if ai.provider == "custom1" or ai.provider == "custom2" then
-                    if (config.endpoint or ""):find("openrouter.ai") then
+                    if (config.endpoint or ""):find("openrouter.ai", 1, true) then
                         headers["HTTP-Referer"]      = "https://github.com/koreader/koreader-xray-plugin"
                         headers["X-Title"] = "KOReader X-Ray"
+                        headers["Accept"] = "text/event-stream"
+                        req_body.stream = true
+                        stream_format = "openai"
                     end
                     -- Per-slot "Is Reasoning Model" setting: raise token ceiling to accommodate reasoning chains
                     local is_reasoning = self.settings and self.settings[ai.provider .. "_is_reasoning"]
@@ -426,7 +434,14 @@ function AIHelper:buildComprehensiveRequest(title, author, context, prompt_overr
                 
                 body = json.encode(req_body)
             end
-            table.insert(requests, { url = url, headers = headers, body = body, provider = ai.provider, model = resolved_model or ai.model })
+            table.insert(requests, {
+                url = url,
+                headers = headers,
+                body = body,
+                provider = ai.provider,
+                model = resolved_model or ai.model,
+                stream_format = stream_format,
+            })
         end
     end
     
@@ -527,6 +542,81 @@ function AIHelper:_scheduleAsyncChildReap(pid)
     return true
 end
 
+function AIHelper:normalizeOpenRouterStream(response_text, stream_format)
+    if stream_format ~= "openai" and stream_format ~= "anthropic" then
+        return nil, "Unsupported OpenRouter stream format"
+    end
+
+    local content = {}
+    local stream_complete = false
+
+    for line in ((response_text or "") .. "\n"):gmatch("(.-)\n") do
+        line = line:gsub("\r$", "")
+        if line:sub(1, 5) == "data:" then
+            local payload = line:sub(6):match("^%s*(.-)%s*$")
+            if payload == "[DONE]" then
+                stream_complete = true
+            elseif payload ~= "" then
+                local ok, event = pcall(json.decode, payload)
+                if not ok or type(event) ~= "table" then
+                    return nil, "OpenRouter returned malformed stream data"
+                end
+                if event.error then
+                    local message = type(event.error) == "table" and event.error.message or event.error
+                    return nil, tostring(message or "OpenRouter stream failed")
+                end
+
+                if stream_format == "openai" then
+                    local choice = event.choices and event.choices[1]
+                    local delta = choice and choice.delta
+                    if delta and type(delta.content) == "string" then
+                        table.insert(content, delta.content)
+                    end
+                    if choice and choice.finish_reason == "error" then
+                        return nil, "OpenRouter stream failed"
+                    end
+                else
+                    if event.type == "content_block_start"
+                        and event.content_block
+                        and type(event.content_block.text) == "string" then
+                        table.insert(content, event.content_block.text)
+                    elseif event.type == "content_block_delta"
+                        and event.delta
+                        and event.delta.type == "text_delta"
+                        and type(event.delta.text) == "string" then
+                        table.insert(content, event.delta.text)
+                    elseif event.type == "message_stop" then
+                        stream_complete = true
+                    elseif event.type == "error" then
+                        return nil, "OpenRouter stream failed"
+                    end
+                end
+            end
+        end
+    end
+
+    if not stream_complete then
+        return nil, "OpenRouter stream ended before completion"
+    end
+
+    local text = table.concat(content)
+    if text == "" then
+        return nil, "OpenRouter stream returned no text"
+    end
+
+    if stream_format == "anthropic" then
+        return json.encode({
+            content = {{ type = "text", text = text }},
+        })
+    end
+    return json.encode({
+        choices = {{
+            finish_reason = "stop",
+            message = { role = "assistant", content = text },
+        }},
+    })
+end
+
 -- Fork a child process to perform the HTTP request. Returns true if started.
 function AIHelper:makeRequestAsync(request_params, result_file)
     if self._async_child_pid and not self:_reapAsyncChild(self._async_child_pid) then
@@ -589,6 +679,19 @@ function AIHelper:makeRequestAsync(request_params, result_file)
                             "AIHelper Child: Incomplete response from %s — got %d bytes, expected %d. Treating as failure.",
                             req.provider, #response_text, clen))
                         code_num = nil -- prevents falling into the code_num==200 block below
+                    end
+                end
+
+                if code_num == 200 and req.stream_format then
+                    local normalized, stream_error = self:normalizeOpenRouterStream(response_text, req.stream_format)
+                    if normalized then
+                        response_text = normalized
+                    else
+                        code = 502
+                        code_num = 502
+                        response_text = json.encode({
+                            error = { message = stream_error },
+                        })
                     end
                 end
 

--- a/xray.koplugin/xray_fetch.lua
+++ b/xray.koplugin/xray_fetch.lua
@@ -137,8 +137,8 @@ function M:fetchSingleWord(text, pos0, pos1)
             if self.destroyed then return end
 
             local result_file = settings_xray_dir .. "/sw_fetch_" .. tostring(os.time()) .. ".json"
-            local started = self.ai_helper:lookupSingleWordAsync(text, context, result_file)
-            if not started then
+            local request_pid = self.ai_helper:lookupSingleWordAsync(text, context, result_file)
+            if not request_pid then
                 if progress_msg then UIManager:close(progress_msg) end
                 self:log("XRayPlugin: Failed to start async lookup")
                 return
@@ -152,7 +152,7 @@ function M:fetchSingleWord(text, pos0, pos1)
             local function poll()
                 if self.destroyed then
                     if self.ai_helper and self.ai_helper.cancelAsyncChild then
-                        self.ai_helper:cancelAsyncChild()
+                        self.ai_helper:cancelAsyncChild(request_pid)
                     end
                     pcall(function() os.remove(result_file) end)
                     self:log("XRayPlugin: Single word lookup cancelled or plugin destroyed")
@@ -172,7 +172,7 @@ function M:fetchSingleWord(text, pos0, pos1)
                 end
                 
                 poll_count = poll_count + 1
-                local data, p_err_code, p_err_msg = self.ai_helper:checkAsyncResult(result_file)
+                local data, p_err_code, p_err_msg = self.ai_helper:checkAsyncResult(result_file, request_pid)
                 if data == nil then
                     if poll_count < max_polls then
                         UIManager:scheduleIn(2, poll)
@@ -1056,7 +1056,7 @@ function M:runPostFetchDuplicateCheck(title, author, reading_percent, is_silent)
                 return
             end
             poll_count = poll_count + 1
-            local data, p_err_code, p_err_msg = self.ai_helper:checkAsyncResult(result_file)
+            local data, p_err_code, p_err_msg = self.ai_helper:checkAsyncResult(result_file, pid)
             if data == nil then
                 if poll_count < max_polls then
                     UIManager:scheduleIn(2, poll)

--- a/xray.koplugin/xray_fetch.lua
+++ b/xray.koplugin/xray_fetch.lua
@@ -323,7 +323,18 @@ function M:_processSingleWordResult(result, text, book_text, current_page)
 end
 
 function M:continueWithFetch(reading_percent, is_update, last_fetch_page, is_silent)
+    self._fetch_generation = (self._fetch_generation or 0) + 1
+    local fetch_generation = self._fetch_generation
+    self._active_fetch_generation = fetch_generation
     self.bg_fetch_active = true
+
+    local function clearFetchState()
+        if self._active_fetch_generation == fetch_generation then
+            self._active_fetch_generation = nil
+            self.bg_fetch_active = false
+        end
+    end
+
     if not self.ai_helper then
         local AIHelper = require(plugin_path .. "xray_aihelper")
         self.ai_helper = AIHelper
@@ -356,6 +367,25 @@ function M:continueWithFetch(reading_percent, is_update, last_fetch_page, is_sil
     -- (which requires an InfoMessage widget and breaks with ButtonDialog).
     local wait_msg
     local is_cancelled = false
+    local result_file
+    local request_pid
+
+    local function finishActiveRequest()
+        request_pid = nil
+        result_file = nil
+        clearFetchState()
+    end
+
+    local function cancelActiveRequest(reason)
+        if request_pid and self.ai_helper and self.ai_helper.cancelAsyncChild then
+            self.ai_helper:cancelAsyncChild(request_pid)
+        end
+        if result_file then
+            pcall(function() os.remove(result_file) end)
+        end
+        finishActiveRequest()
+        self:log("XRayPlugin: " .. reason)
+    end
 
     if not is_silent then
         local ButtonDialog = require("ui/widget/buttondialog")
@@ -369,8 +399,8 @@ function M:continueWithFetch(reading_percent, is_update, last_fetch_page, is_sil
                 text = self.loc:t("cancel") or "Cancel",
                 callback = function()
                     is_cancelled = true
-                    self:log("XRayPlugin: Fetch cancelled by user (button pressed)")
                     if wait_msg then UIManager:close(wait_msg) end
+                    cancelActiveRequest("Fetch cancelled by user")
                 end
             }}}
         }
@@ -378,7 +408,7 @@ function M:continueWithFetch(reading_percent, is_update, last_fetch_page, is_sil
     end
 
     UIManager:scheduleIn(0.5, function()
-        if is_cancelled or self.destroyed then self.bg_fetch_active = false; return end
+        if is_cancelled or self.destroyed then clearFetchState(); return end
         if not self.chapter_analyzer then self.chapter_analyzer = require(plugin_path .. "xray_chapteranalyzer"):new() end
 
         local current_page = self.ui:getCurrentPage()
@@ -426,8 +456,8 @@ function M:continueWithFetch(reading_percent, is_update, last_fetch_page, is_sil
         end
 
         UIManager:scheduleIn(0, function()
-            if is_cancelled or self.destroyed then self.bg_fetch_active = false; return end
-            if not self.ui or not self.ui.document then self.bg_fetch_active = false; return end
+            if is_cancelled or self.destroyed then clearFetchState(); return end
+            if not self.ui or not self.ui.document then clearFetchState(); return end
 
             local samples, chapter_titles = self.chapter_analyzer:getDetailedChapterSamples(self.ui, 200, 150000, reading_percent == 100, first_missing_page, known_chapters)
             local annots = self.chapter_analyzer:getAnnotationsForAnalysis(self.ui)
@@ -436,7 +466,7 @@ function M:continueWithFetch(reading_percent, is_update, last_fetch_page, is_sil
                 if wait_msg then UIManager:close(wait_msg) end
                 if not is_silent then UIManager:show(InfoMessage:new{ text = self.loc:t("error_extract_text") or "Error: Could not extract book text.", timeout = 5 }) end
                 self:log("XRayPlugin: Text extraction failed" .. (is_silent and " (silent)" or ""))
-                self.bg_fetch_active = false
+                clearFetchState()
                 return
             end
 
@@ -459,7 +489,7 @@ function M:continueWithFetch(reading_percent, is_update, last_fetch_page, is_sil
             if not req_params then
                 if wait_msg then UIManager:close(wait_msg) end
                 self:log("XRayPlugin: Failed to build request: " .. tostring(err_msg))
-                self.bg_fetch_active = false
+                clearFetchState()
                 if not is_silent then
                     local title, text = utils:getFriendlyError(err_code, err_msg, self.loc)
                     UIManager:show(ConfirmBox:new{
@@ -489,38 +519,37 @@ function M:continueWithFetch(reading_percent, is_update, last_fetch_page, is_sil
                 end
             end)
 
-            local result_file = settings_xray_dir .. "/bg_fetch_" .. tostring(os.time()) .. ".json"
+            result_file = settings_xray_dir .. "/bg_fetch_" .. tostring(os.time()) .. "_" .. tostring(fetch_generation) .. ".json"
             local started = self.ai_helper:makeRequestAsync(req_params, result_file)
             if not started then
                 if wait_msg then UIManager:close(wait_msg) end
                 self:log("XRayPlugin: Failed to start async fetch")
-                self.bg_fetch_active = false
+                pcall(function() os.remove(result_file) end)
+                result_file = nil
+                clearFetchState()
                 return
             end
+            request_pid = started
 
             local poll_count = 0
             local max_polls = 300 -- 10 minutes at 2s intervals
             local function poll()
                 if is_cancelled or self.destroyed then
-                    pcall(function() os.remove(result_file) end)
-                    self.bg_fetch_active = false
-                    self:log("XRayPlugin: Fetch cancelled or plugin destroyed")
+                    cancelActiveRequest(self.destroyed and "Fetch stopped because plugin was destroyed" or "Fetch cancelled")
                     return
                 end
                 if not self.ui or not self.ui.document then
-                    pcall(function() os.remove(result_file) end)
-                    self.bg_fetch_active = false
+                    cancelActiveRequest("Fetch stopped because the document was closed")
                     return
                 end
                 poll_count = poll_count + 1
-                local data, p_err_code, p_err_msg = self.ai_helper:checkAsyncResult(result_file)
+                local data, p_err_code, p_err_msg = self.ai_helper:checkAsyncResult(result_file, request_pid)
                 if data == nil then
                     if poll_count < max_polls then
                         UIManager:scheduleIn(2, poll)
                     else
                         if wait_msg then UIManager:close(wait_msg) end
-                        self.bg_fetch_active = false
-                        self:log("XRayPlugin: Fetch timed out")
+                        cancelActiveRequest("Fetch timed out")
                         if not is_silent then
                             local title, text = utils:getFriendlyError("error_timeout", nil, self.loc)
                             UIManager:show(ConfirmBox:new{
@@ -532,7 +561,7 @@ function M:continueWithFetch(reading_percent, is_update, last_fetch_page, is_sil
                     end
                 elseif data == false then
                     if wait_msg then UIManager:close(wait_msg) end
-                    self.bg_fetch_active = false
+                    finishActiveRequest()
                     self:log("XRayPlugin: Fetch failed: " .. tostring(p_err_msg))
                     if not is_silent then
                         local title, text = utils:getFriendlyError(p_err_code, p_err_msg, self.loc)
@@ -544,7 +573,7 @@ function M:continueWithFetch(reading_percent, is_update, last_fetch_page, is_sil
                     end
                 else
                     if wait_msg then UIManager:close(wait_msg) end
-                    self.bg_fetch_active = false
+                    finishActiveRequest()
                     self:finalizeXRayData(data, title, author, book_text, is_update, is_silent, current_page)
                 end
             end

--- a/xray.koplugin/xray_ui.lua
+++ b/xray.koplugin/xray_ui.lua
@@ -4387,8 +4387,8 @@ function M:checkSeriesContext()
     local DataStorage = require("datastorage")
     local result_file = DataStorage:getSettingsDir() .. "/xray/bg_series_detect_" .. tostring(os.time()) .. ".json"
     
-    local started = self.ai_helper:makeRequestAsync(req_params, result_file)
-    if not started then
+    local request_pid = self.ai_helper:makeRequestAsync(req_params, result_file)
+    if not request_pid then
         self:log("XRayPlugin: Series: Async check not supported/failed (e.g. on Windows). Skipping automatic AI fallback.")
         return
     end
@@ -4405,7 +4405,7 @@ function M:checkSeriesContext()
             return
         end
         poll_count = poll_count + 1
-        local result, p_err_code, p_err_msg = self.ai_helper:checkAsyncResult(result_file)
+        local result, p_err_code, p_err_msg = self.ai_helper:checkAsyncResult(result_file, request_pid)
         if result == nil then
             if poll_count < max_polls then
                 UIManager:scheduleIn(2, pollDetect)


### PR DESCRIPTION
Currently, when a user cancels an X-Ray request, it continues running in the background, using battery and network resources.

This PR adds support for terminating and cleaning up the active request process. OpenRouter requests also now use streaming, allowing supported providers to stop server-side processing and billing when cancelled.